### PR TITLE
Changes fs to localStorage

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,5 @@
 node_modules
 
-src/
-
 .vite/
 dist/**/*.map
 *.local

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@solarpunkltd/file-manager-lib",
-  "version": "0.0.0",
+  "version": "0.0.8",
   "description": "A file manager for storing and handling data on Swarm.",
-  "main": "dist/fileManager.js",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "node --loader ts-node/esm node_modules/jest/bin/jest.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,4 +14,4 @@ export const INVALID_STMAP = '0'.repeat(64);
 export const SWARM_ZERO_ADDRESS = '0'.repeat(64);
 
 // TEMPORARY
-export const FILE_INFO_PATH = './data.txt';
+export const FILE_INFO_LOCAL_STORAGE = 'data.txt';

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -1,7 +1,6 @@
 import { BatchId } from '@ethersphere/bee-js';
-import fs from 'fs';
 
-import { FILE_INFO_PATH } from './constants';
+import { FILE_INFO_LOCAL_STORAGE } from './constants';
 import { FileInfo, ShareItem } from './types';
 
 export class FileManager {
@@ -18,7 +17,11 @@ export class FileManager {
   }
 
   private async initFileInfoList(): Promise<void> {
-    const rawData = fs.readFileSync(FILE_INFO_PATH, 'utf8');
+    const rawData = localStorage.getItem(FILE_INFO_LOCAL_STORAGE);
+    if (!rawData) {
+      console.error('No data found in data.txt (localStorage');
+      return;
+    }
     const data = JSON.parse(rawData);
 
     if (!Array.isArray(data)) {
@@ -44,7 +47,7 @@ export class FileManager {
       this.fileInfoList.push(fileInfo);
 
       const data = JSON.stringify(this.fileInfoList);
-      fs.writeFileSync(FILE_INFO_PATH, data);
+      localStorage.setItem(FILE_INFO_LOCAL_STORAGE, data);
 
       return index.toString(16).padStart(64, '0');
     } catch (error) {

--- a/tests/fileManager.test.ts
+++ b/tests/fileManager.test.ts
@@ -1,9 +1,19 @@
-import fs from 'fs';
-
 import { FileManager } from '../src/fileManager';
 
 import { emptyFileInfoTxt, extendedFileInfoTxt, fileInfoTxt, mockBatchId } from './mockHelpers';
 //import { ShareItem } from 'src/types';
+
+Object.defineProperty(global, 'localStorage', {
+  value: {
+    getItem: jest.fn(() => null),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+    clear: jest.fn(),
+    length: 0,
+    key: jest.fn(),
+  },
+  writable: true,
+});
 
 describe('initialize', () => {
   beforeEach(() => {
@@ -11,7 +21,7 @@ describe('initialize', () => {
   });
 
   it('should load FileInfo list into memory', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
 
     const fileManager = new FileManager();
     await fileManager.initialize();
@@ -29,7 +39,7 @@ describe('initialize', () => {
   });
 
   it('should throw an error if fileInfoList is not an array', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(`{
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(`{
       "fileInfoList": "not an array"
     }`);
 
@@ -50,9 +60,9 @@ describe('saveFileInfo', () => {
   });
 
   it('should save new FileInfo into data.txt', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
-    jest.spyOn(fs, 'writeFileSync').mockReturnValue();
-    const writeFileSync = jest.spyOn(fs, 'writeFileSync');
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'setItem').mockReturnValue();
+    const writeFileSync = jest.spyOn(localStorage, 'setItem');
 
     const fileManager = new FileManager();
     await fileManager.initialize();
@@ -68,7 +78,7 @@ describe('saveFileInfo', () => {
   });
 
   it('should throw an error if fileInfo is invalid', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(emptyFileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(emptyFileInfoTxt);
     const fileManager = new FileManager();
     await fileManager.initialize();
     const fileManagerSpy = jest.spyOn(fileManager, 'saveFileInfo');
@@ -88,8 +98,8 @@ describe('saveFileInfo', () => {
   });
 
   it('should throw an error if there is an error saving the file info', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
-    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'setItem').mockImplementation(() => {
       throw new Error('Error saving file info');
     });
 
@@ -116,7 +126,7 @@ describe('listFiles', () => {
   });
 
   it('should list paths (refs) for given input list', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
     const fileManager = new FileManager();
     await fileManager.initialize();
     const list = fileManager.getFileInfoList();
@@ -133,7 +143,7 @@ describe('upload', () => {
   });
 
   it('should save FileInfo', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
     const fileManager = new FileManager();
     await fileManager.initialize();
 
@@ -147,7 +157,7 @@ describe('upload', () => {
   });
 
   it('should give back ref (currently index)', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
     const fileManager = new FileManager();
     await fileManager.initialize();
 
@@ -157,7 +167,7 @@ describe('upload', () => {
   });
 
   it('should work with consecutive uploads', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
     const fileManager = new FileManager();
     await fileManager.initialize();
 
@@ -215,7 +225,7 @@ describe('upload and listFiles', () => {
   });
 
   it('should give back correct refs by listFiles, after upload', async () => {
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileInfoTxt);
+    jest.spyOn(localStorage, 'getItem').mockReturnValue(fileInfoTxt);
     const fileManager = new FileManager();
     await fileManager.initialize();
 

--- a/tests/fileManager.test.ts
+++ b/tests/fileManager.test.ts
@@ -5,7 +5,6 @@ import { FileManager } from '../src/fileManager';
 import { emptyFileInfoTxt, extendedFileInfoTxt, fileInfoTxt, mockBatchId } from './mockHelpers';
 //import { ShareItem } from 'src/types';
 
-
 describe('initialize', () => {
   beforeEach(() => {
     jest.resetAllMocks();

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -11,6 +11,6 @@ export const fileInfoTxt = `[
   }
 ]`;
 
-export const extendedFileInfoTxt = `[{"batchId":"ee0fec26fdd55a1b8a777cc8c84277a1b16a7da318413fbd4cc4634dd93a2c51","eFileRef":"src/folder/1.txt"},{"batchId\":\"ee0fec26fdd55a1b8a777cc8c84277a1b16a7da318413fbd4cc4634dd93a2c51\",\"eFileRef\":\"src/folder/2.txt\"},{\"batchId\":\"ee0fec26fdd55a1b8a777cc8c84277a1b16a7da318413fbd4cc4634dd93a2c51\",\"eFileRef\":\"src/folder/3.txt\"}]`;
+export const extendedFileInfoTxt = `[{"batchId":"ee0fec26fdd55a1b8a777cc8c84277a1b16a7da318413fbd4cc4634dd93a2c51","eFileRef":"src/folder/1.txt"},{"batchId":"ee0fec26fdd55a1b8a777cc8c84277a1b16a7da318413fbd4cc4634dd93a2c51","eFileRef":"src/folder/2.txt"},{"batchId":"ee0fec26fdd55a1b8a777cc8c84277a1b16a7da318413fbd4cc4634dd93a2c51","eFileRef":"src/folder/3.txt"}]`;
 
 export const emptyFileInfoTxt = `[]`;


### PR DESCRIPTION
## Changes fs to localStorage
### Description

Changes `fs` to `localStorage`, because front end won't have `localStorage`.

### Changes Made

 - changes fs to localStorage at read
 - changes fs to localStorage at write
 - adjusts unit tests
 - removes `src/` from `.npmignore`, because it will cause the package not to have `src` under `/dist`.

### How Has This Been Tested?

`npm run test`


### Checklist

- none