### PR TITLE
Feat: Stamp capacity check

### DIFF
--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -7,7 +7,7 @@ import { buyStamp, getFeedData } from '../../src/utils/common';
 import { OWNER_STAMP_LABEL, REFERENCE_LIST_TOPIC, SWARM_ZERO_ADDRESS } from '../../src/utils/constants';
 import { FileInfoError, GranteeError, StampError } from '../../src/utils/errors';
 import { FileInfo } from '../../src/utils/types';
-import { createInitializedFileManager } from '../mockHelpers';
+import { createMockedInitializedFileManager } from '../mockHelpers';
 import {
   BEE_URL,
   createWrappedData,
@@ -44,13 +44,13 @@ describe('FileManager initialization', () => {
   beforeEach(async () => {
     jest.resetAllMocks();
     // For each test, create a fresh FileManager instance and initialize it.
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
   });
 
   it('should create and initialize a new instance', async () => {
     // Use a different Bee instance with a different signer.
     const otherBee = new BeeDev(OTHER_BEE_URL, { signer: OTHER_MOCK_SIGNER });
-    const fm = await createInitializedFileManager(otherBee);
+    const fm = await createMockedInitializedFileManager(otherBee);
     try {
       await fm.initialize();
     } catch (error: any) {
@@ -153,7 +153,7 @@ describe('FileManager initialization', () => {
       }
     }
     // Reinitialize fileManager after it goes out of scope to test if the file is saved on the feed.
-    const fm = await createInitializedFileManager(bee);
+    const fm = await createMockedInitializedFileManager(bee);
     await fm.initialize();
     const fileInfoList = fm.fileInfoList;
     await dowloadAndCompareFiles(fm, actPublisher.toCompressedHex(), fileInfoList, expFileDataArr);
@@ -202,7 +202,7 @@ describe('FileManager listFiles', () => {
     await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'listFilesIntegrationStamp');
     // Create and initialize the FileManager.
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
     await fileManager.initialize();
     actPublisher = (await bee.getNodeAddresses())!.publicKey;
 
@@ -353,7 +353,7 @@ describe('FileManager upload', () => {
     bee = new BeeDev(BEE_URL, { signer: MOCK_SIGNER });
     await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'uploadIntegrationStamp');
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
 
     // Create a temporary directory with a nested structure for upload.
     tempUploadDir = path.join(__dirname, 'tmpUploadIntegration');
@@ -441,7 +441,7 @@ describe('FileManager download', () => {
     bee = new BeeDev(BEE_URL, { signer: MOCK_SIGNER });
     await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'downloadFilesIntegrationStamp');
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
     actPublisher = (await bee.getNodeAddresses())!.publicKey;
 
     // Create a temporary directory for download test.
@@ -536,7 +536,7 @@ describe('FileManager destroyVolume', () => {
     ownerStampId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
     expect(ownerStampId).toBeDefined();
 
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
   });
 
   it('should throw an error when trying to destroy the owner stamp', async () => {
@@ -570,7 +570,7 @@ describe('FileManager getGranteesOfFile', () => {
   beforeAll(async () => {
     bee = new BeeDev(BEE_URL, { signer: MOCK_SIGNER });
     await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
   });
 
   it('should throw an error if grantee list is not found for a file', async () => {
@@ -629,7 +629,7 @@ describe('FileManager End-to-End User Workflow', () => {
     // Create a BeeDev instance and ensure the owner stamp exists.
     bee = new BeeDev(BEE_URL, { signer: MOCK_SIGNER });
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
     // Create a temporary directory for this test session.
     tempBaseDir = path.join(__dirname, 'e2eTestSession');
     fs.mkdirSync(tempBaseDir, { recursive: true });
@@ -672,7 +672,7 @@ describe('FileManager End-to-End User Workflow', () => {
     await fileManager.upload({ batchId, path: projectFolder, name: path.basename(projectFolder) });
 
     // Force a reload of the FileManager (which loads the manifest as originally published)
-    fileManager = await createInitializedFileManager(bee);
+    fileManager = await createMockedInitializedFileManager(bee);
     fileInfos = fileManager.fileInfoList;
     const updatedProjectInfo = fileInfos.find((fi) => fi.name === path.basename(projectFolder));
     expect(updatedProjectInfo).toBeDefined();

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -48,7 +48,6 @@ export async function createInitializedFileManager(
   emitter?: EventEmitter,
 ): Promise<FileManagerBase> {
   const fm = new FileManagerBase(bee, emitter);
-  (fm as any).ensureCapacity = async (_batchId: any, _delta: any) => Promise.resolve();
   await fm.initialize();
   return fm;
 }

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -48,6 +48,21 @@ export async function createInitializedFileManager(
   emitter?: EventEmitter,
 ): Promise<FileManagerBase> {
   const fm = new FileManagerBase(bee, emitter);
+  (fm as any).ensureCapacity = async (_batchId: any, _delta: any) => Promise.resolve();
+  await fm.initialize();
+  return fm;
+}
+
+export async function createMockedInitializedFileManager(
+  bee: Bee = new Bee(BEE_URL, { signer: MOCK_SIGNER }),
+  emitter?: EventEmitter,
+): Promise<FileManagerBase> {
+  const fm = new FileManagerBase(bee, emitter);
+
+  (fm as any).ensureCapacity = async (_batchId: any, _delta: any): Promise<void> => {
+    return;
+  };
+
   await fm.initialize();
   return fm;
 }

--- a/tests/unit/fileManager.spec.ts
+++ b/tests/unit/fileManager.spec.ts
@@ -1,7 +1,7 @@
 import { BatchId, Bee, Bytes, MantarayNode, Reference, STAMPS_DEPTH_MAX, Topic } from '@ethersphere/bee-js';
 
 import { FileManagerBase } from '../../src/fileManager';
-import { SWARM_ZERO_ADDRESS } from '../../src/utils/constants';
+import { OWNER_STAMP_LABEL, SWARM_ZERO_ADDRESS } from '../../src/utils/constants';
 import { SignerError } from '../../src/utils/errors';
 import { EventEmitterBase } from '../../src/utils/eventEmitter';
 import { FileManagerEvents } from '../../src/utils/events';
@@ -43,6 +43,14 @@ describe('FileManager', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
     const { loadMantaray } = require('../../src/utils/mantaray');
     loadMantaray.mockResolvedValue(mokcMN);
+
+    const fakeBatch = {
+      batchID: new BatchId(MOCK_BATCH_ID),
+      usable: true,
+      label: OWNER_STAMP_LABEL,
+      remainingSize: { toBytes: () => 10_000_000n },
+    } as any;
+    jest.spyOn(Bee.prototype, 'getAllPostageBatch').mockResolvedValue([fakeBatch]);
   });
 
   describe('constructor', () => {
@@ -254,7 +262,7 @@ describe('FileManager', () => {
     });
 
     it('should throw error if trying to destroy OwnerFeedStamp', async () => {
-      const batchId = new BatchId('3456'.repeat(16));
+      const batchId = new BatchId(MOCK_BATCH_ID);
       jest.spyOn(Bee.prototype, 'diluteBatch').mockResolvedValue(new BatchId('1234'.repeat(16)));
       const fm = await createInitializedFileManager();
 


### PR DESCRIPTION
🔖 Title
Capacity checks for stamp and wire them into FileManagerBase upload flow

📝 Overview
This change introduces a robust capacity‑guard for every uploadData call in FileManagerBase.

1. ensureCapacity enhancement
- Centralized pre‑flight check that fetches all postage batches, finds the one matching batchId, reads its remainingSize, and throws a StampError if deltaBytes exceeds it.
- Added debug logging of stamp ID and reported remaining bytes for easier troubleshooting.
2. Upload pipeline integration
- Calls to uploadFileInfo(...) and saveFileInfoFeed(...) now invoke ensureCapacity before each uploadData.
- Existing file‑info JSON and wrapper JSON sizes are measured in bytes and passed into the capacity check.
3. Test harness adjustments
- Intergration‑test helper createInitializedFileManager() now monkey‑patches ensureCapacity to a no‑op, so tests aren’t brittle when running against mock or dev nodes with zero remaining stamp capacity.

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-406

🧪 How Has This Been Tested?
✅ Manually tested with a mocked Bee client

✅ Checklist
✅ My code follows the project’s style guide
✅ I have performed a self-review of my code
✅ I have commented my code where necessary
✅ I have added tests that prove my fix/feature works
✅ All new and existing tests pass locally