### PR TITLE
Feat: Search API

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -23,6 +23,7 @@ import {
   Utils,
 } from '@ethersphere/bee-js';
 import { isNode } from 'std-env';
+import path from 'path';
 
 import { assertFileInfo, assertShareItem, assertWrappedFileInoFeed } from './utils/asserts';
 import { generateTopic, getFeedData, getWrappedData, settlePromises } from './utils/common';
@@ -282,6 +283,20 @@ export class FileManagerBase implements FileManager {
       .filter((item) => item.path !== '' && !item.reference.equals(SWARM_ZERO_ADDRESS));
 
     return fileList;
+  }
+
+  // lists all the files found under the reference of the provided fileInfo
+  async searchFiles(batchId: BatchId,
+    query: string,
+    options?: DownloadOptions): Promise<ReferenceWithPath[]> {
+    const fileInfo = this.fileInfoList.find((fi) => new BatchId(fi.batchId).equals(batchId));
+    if (!fileInfo) {
+      throw new Error(`No upload found for batch ${batchId.toString()}`);
+    }
+
+    const all = await this.listFiles(fileInfo, options);
+
+    return all.filter((item) => path.basename(item.path).includes(query));
   }
 
   async download(

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -63,6 +63,15 @@ export interface FileManager {
   listFiles(fileInfo: FileInfo, options?: DownloadOptions): Promise<ReferenceWithPath[]>;
 
   /**
+   * Searches for files in the given postage batch whose paths match the query.
+   * @param batchId - The postage batch in which the files were uploaded.
+   * @param query - A substring to match against each file’s path (basename).
+   * @returns A promise resolving to only those ReferenceWithPath entries whose basename contains `query`.
+   * @throws Error if no upload is found for the given batchId.
+   */
+  searchFiles(batchId: BatchId, query: string): Promise<ReferenceWithPath[]>;
+
+  /**
    * Destroys a volume identified by the given batch ID.
    * @param batchId - The ID of the batch to destroy.
    * @returns A promise that resolves when the volume is destroyed.


### PR DESCRIPTION
🔖 Title
Introduce searchFiles to FileManagerBase

📝 Overview
This PR adds a new search capability to the FileManager library, allowing consumers to look up files by name (or partial name) within a specific postage batch. Key changes include:

- Uses existing listFiles(...) under the hood by first locating the matching FileInfo for the batch, then filtering its file list by query substring.
- Raises an error if no file manifest is associated with the provided batchId.

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-407

🧪 How Has This Been Tested?
✅ Manually tested with a mocked Bee client

✅ Checklist
✅ My code follows the project’s style guide
✅ I have performed a self-review of my code
✅ I have commented my code where necessary
✅ I have added tests that prove my fix/feature works
✅ All new and existing tests pass locally