### PR TITLE
Feat/spdv 469 version control only info

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -89,13 +89,13 @@ export class FileManagerBase implements FileManager {
   // TODO: import pins
   async initialize(): Promise<void> {
     if (this.isInitialized) {
-      console.log('FileManager is already initialized');
+      console.debug('FileManager is already initialized');
       this.emitter.emit(FileManagerEvents.FILEMANAGER_INITIALIZED, true);
       return;
     }
 
     if (this.isInitializing) {
-      console.log('FileManager is being initialized');
+      console.debug('FileManager is being initialized');
       return;
     }
 
@@ -339,7 +339,12 @@ export class FileManagerBase implements FileManager {
 
     let file: ReferenceWithHistory;
 
-    if (!infoOptions.info.file) {
+    if (infoOptions.info.file) {
+      file = {
+        reference: infoOptions.info.file.reference.toString(),
+        historyRef: infoOptions.info.file.historyRef.toString(),
+      };
+    } else {
       let uploadResult: UploadResult;
       if (isNode) {
         uploadResult = await uploadNode(this.bee, infoOptions, uploadOptions, requestOptions);
@@ -355,11 +360,6 @@ export class FileManagerBase implements FileManager {
       file = {
         reference: uploadResult.reference.toString(),
         historyRef: uploadResult.historyAddress.getOrThrow().toString(),
-      };
-    } else {
-      file = {
-        reference: infoOptions.info.file.reference.toString(),
-        historyRef: infoOptions.info.file.historyRef.toString(),
       };
     }
 
@@ -379,6 +379,10 @@ export class FileManagerBase implements FileManager {
     };
 
     await this.saveFileInfoFeed(fileInfo, requestOptions);
+
+    if (infoOptions.info.file) {
+      return;
+    }
 
     const ix = this.ownerFeedList.findIndex((f) => f.topic.toString() === fileInfo.topic.toString());
     if (ix !== -1) {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -380,21 +380,19 @@ export class FileManagerBase implements FileManager {
 
     await this.saveFileInfoFeed(fileInfo, requestOptions);
 
-    if (infoOptions.info.file) {
-      return;
-    }
+    if (!infoOptions.info.file) {
+      const ix = this.ownerFeedList.findIndex((f) => f.topic.toString() === topicStr);
+      if (ix !== -1) {
+        this.ownerFeedList[ix] = {
+          topic: topicStr,
+          eGranteeRef: this.ownerFeedList[ix].eGranteeRef?.toString(),
+        };
+      } else {
+        this.ownerFeedList.push({ topic: topicStr });
+      }
 
-    const ix = this.ownerFeedList.findIndex((f) => f.topic.toString() === fileInfo.topic.toString());
-    if (ix !== -1) {
-      this.ownerFeedList[ix] = {
-        topic: fileInfo.topic.toString(),
-        eGranteeRef: this.ownerFeedList[ix].eGranteeRef?.toString(),
-      };
-    } else {
-      this.ownerFeedList.push({ topic: fileInfo.topic.toString() });
+      await this.saveOwnerFeedList(requestOptions);
     }
-
-    await this.saveOwnerFeedList(requestOptions);
 
     this.emitter.emit(FileManagerEvents.FILE_UPLOADED, { fileInfo });
   }

--- a/src/upload/upload.browser.ts
+++ b/src/upload/upload.browser.ts
@@ -14,7 +14,7 @@ export async function uploadBrowser(
   }
 
   const uploadFilesRes = await bee.streamFiles(
-    infoOptions.batchId,
+    infoOptions.info.batchId,
     infoOptions.files,
     infoOptions.onUploadProgress,
     { ...uploadOptions, act: false },
@@ -23,7 +23,7 @@ export async function uploadBrowser(
   let uploadPreviewRes: UploadResult | undefined;
   if (infoOptions.preview) {
     uploadPreviewRes = await bee.streamFiles(
-      infoOptions.batchId,
+      infoOptions.info.batchId,
       [infoOptions.preview],
       infoOptions.onUploadProgress,
       { ...uploadOptions, act: false },
@@ -37,7 +37,7 @@ export async function uploadBrowser(
   };
 
   return await bee.uploadData(
-    infoOptions.batchId,
+    infoOptions.info.batchId,
     JSON.stringify(wrappedData),
     { ...uploadOptions, act: true },
     requestOptions,

--- a/src/upload/upload.node.ts
+++ b/src/upload/upload.node.ts
@@ -23,7 +23,7 @@ export async function uploadNode(
 
   const uploadFilesRes = await uploadFileOrDirectory(
     bee,
-    infoOptions.batchId,
+    new BatchId(infoOptions.info.batchId),
     infoOptions.path,
     { ...uploadOptions, act: false },
     requestOptions,
@@ -32,7 +32,7 @@ export async function uploadNode(
   if (infoOptions.previewPath) {
     uploadPreviewRes = await uploadFileOrDirectory(
       bee,
-      infoOptions.batchId,
+      new BatchId(infoOptions.info.batchId),
       infoOptions.previewPath,
       { ...uploadOptions, act: false },
       requestOptions,
@@ -45,7 +45,7 @@ export async function uploadNode(
   };
 
   return await bee.uploadData(
-    infoOptions.batchId,
+    infoOptions.info.batchId,
     JSON.stringify(wrappedData),
     { ...uploadOptions, act: true },
     requestOptions,

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -17,6 +17,7 @@ import { FeedResultWithIndex, FeedPayloadResult, WrappedUploadResult } from './t
 import { FileInfoError } from './errors';
 import { asserWrappedUploadResult } from './asserts';
 
+// TODO: use downloadPayload() and do not unwrap the data
 export async function getFeedData(
   bee: Bee,
   topic: Topic,

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -11,7 +11,7 @@ import {
 import { isNode } from 'std-env';
 
 import { getRandomBytesBrowser } from './browser';
-import { SWARM_ZERO_ADDRESS } from './constants';
+import { FEED_INDEX_ZERO, SWARM_ZERO_ADDRESS } from './constants';
 import { getRandomBytesNode } from './node';
 import { FeedPayloadResult, WrappedUploadResult } from './types';
 import { FileInfoError } from './errors';
@@ -35,7 +35,7 @@ export async function getFeedData(
     if (isNotFoundError(error)) {
       return {
         feedIndex: FeedIndex.MINUS_ONE,
-        feedIndexNext: FeedIndex.fromBigInt(0n),
+        feedIndexNext: FEED_INDEX_ZERO,
         payload: SWARM_ZERO_ADDRESS,
       };
     }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -13,7 +13,7 @@ import { isNode } from 'std-env';
 import { getRandomBytesBrowser } from './browser';
 import { FEED_INDEX_ZERO, SWARM_ZERO_ADDRESS } from './constants';
 import { getRandomBytesNode } from './node';
-import { FeedResultWithIndex, FeedReferenceResult, WrappedUploadResult } from './types';
+import { FeedResultWithIndex, FeedPayloadResult, WrappedUploadResult } from './types';
 import { FileInfoError } from './errors';
 import { asserWrappedUploadResult } from './asserts';
 
@@ -25,25 +25,25 @@ export async function getFeedData(
   options?: BeeRequestOptions,
 ): Promise<FeedResultWithIndex> {
   try {
-    let data: FeedReferenceResult;
+    let data: FeedPayloadResult;
     const feedReader = bee.makeFeedReader(topic.toUint8Array(), address, options);
     if (index !== undefined) {
-      data = await feedReader.downloadReference({ index: FeedIndex.fromBigInt(index) });
+      data = await feedReader.download({ index: FeedIndex.fromBigInt(index) });
     } else {
-      data = await feedReader.downloadReference();
+      data = await feedReader.download();
     }
 
     return {
       feedIndex: data.feedIndex,
       feedIndexNext: data.feedIndexNext ?? data.feedIndex.next(),
-      reference: data.reference,
+      payload: data.payload,
     };
   } catch (error) {
     if (isNotFoundError(error)) {
       return {
         feedIndex: FeedIndex.MINUS_ONE,
         feedIndexNext: FEED_INDEX_ZERO,
-        reference: SWARM_ZERO_ADDRESS,
+        payload: SWARM_ZERO_ADDRESS,
       };
     }
     throw error;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import { NULL_ADDRESS, Reference, Topic } from '@ethersphere/bee-js';
+import { FeedIndex, NULL_ADDRESS, Reference, Topic } from '@ethersphere/bee-js';
 
 export const REFERENCE_LIST_TOPIC = Topic.fromString('reference-list');
 export const SHARED_INBOX_TOPIC = Topic.fromString('shared-inbox');
@@ -6,3 +6,4 @@ export const SHARED_WITH_ME_TOPIC = 'shared-with-me';
 export const OWNER_STAMP_LABEL = 'owner';
 export const ROOT_PATH = '/';
 export const SWARM_ZERO_ADDRESS = new Reference(NULL_ADDRESS);
+export const FEED_INDEX_ZERO = FeedIndex.fromBigInt(0n);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -101,25 +101,21 @@ export interface FileManager {
 
   /**
    * Returns a specific version of a file.
-   * 
-   * @param fi - The base FileInfo containing topic and owner fields.
+   *
+   * @param fileInfo - The base FileInfo containing topic and owner fields.
    * @param version - Optional desired version slot as a FeedIndex or hex/string. If omitted, fetches latest.
-   * @returns The FileInfo corresponding to the requested version, either from cache or fetched from chain.
+   * @returns The FileInfo corresponding to the requested version, either cached or fetched.
    */
   getVersion(fileInfo: FileInfo, version?: FeedIndex): Promise<FileInfo>;
 
-
   /**
    * Restore a previous version of a file as the new “head” in your feed.
-   * 
+   *
    * @param versionToRestore - The FileInfo instance representing the version to restore.
    * @param requestOptions - Optional BeeRequestOptions for upload operations.
-   * @throws FileInfoError if no versions are found on-chain.
+   * @throws FileInfoError if no versions are found.
    */
-  restoreVersion(
-    fileInfo: FileInfo,
-    requestOptions?: BeeRequestOptions
-  ): Promise<void>;
+  restoreVersion(versionToRestore: FileInfo, requestOptions?: BeeRequestOptions): Promise<void>;
 
   /**
    * Retrieves a list of file information.
@@ -149,7 +145,7 @@ export interface FileInfo {
   timestamp?: number;
   shared?: boolean;
   preview?: ReferenceWithHistory;
-  index?: string | undefined;
+  version?: string | undefined;
   redundancyLevel?: RedundancyLevel;
   customMetadata?: Record<string, string>;
 }
@@ -161,7 +157,7 @@ export interface FileInfoOptions {
   path?: string;
   customMetadata?: Record<string, string>;
   infoTopic?: string;
-  index?: string | undefined;
+  version?: string | undefined;
   preview?: File;
   previewPath?: string;
   onUploadProgress?: (progress: UploadProgress) => void;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -203,7 +203,7 @@ export interface FeedPayloadResult extends FeedUpdateHeaders {
 export interface FeedReferenceResult extends FeedUpdateHeaders {
   reference: Reference;
 }
-export interface FeedResultWithIndex extends FeedReferenceResult {
+export interface FeedResultWithIndex extends FeedPayloadResult {
   feedIndexNext: FeedIndex;
 }
 export interface UploadProgress {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -150,14 +150,17 @@ export interface FileInfo {
   customMetadata?: Record<string, string>;
 }
 
+export interface PartialFileInfo extends Omit<FileInfo, 'owner' | 'actPublisher' | 'file' | 'topic'> {
+  owner?: string | EthAddress;
+  actPublisher?: string | PublicKey;
+  file?: ReferenceWithHistory;
+  topic?: string | Topic;
+}
+
 export interface FileInfoOptions {
-  batchId: BatchId;
-  name: string;
+  info: PartialFileInfo;
   files?: File[] | FileList;
   path?: string;
-  customMetadata?: Record<string, string>;
-  infoTopic?: string;
-  version?: string | undefined;
   preview?: File;
   previewPath?: string;
   onUploadProgress?: (progress: UploadProgress) => void;
@@ -200,7 +203,9 @@ export interface FeedPayloadResult extends FeedUpdateHeaders {
 export interface FeedReferenceResult extends FeedUpdateHeaders {
   reference: Reference;
 }
-
+export interface FeedResultWithIndex extends FeedReferenceResult {
+  feedIndexNext: FeedIndex;
+}
 export interface UploadProgress {
   total: number;
   processed: number;

--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -353,6 +353,7 @@ describe('FileManager listFiles', () => {
   });
 });
 
+// TODO: test reupload + download with different version
 describe('FileManager upload', () => {
   let bee: BeeDev;
   let fileManager: FileManagerBase;

--- a/tests/integration/test-node-setup/jestSetup.ts
+++ b/tests/integration/test-node-setup/jestSetup.ts
@@ -2,14 +2,13 @@ import { execSync } from 'child_process';
 import Path from 'path';
 
 export default async function globalSetup(): Promise<void> {
-  console.log('Starting Bee Nodes...');
-  // This script now runs the modified shell script that starts two nodes.
+  console.debug('Starting Bee Nodes...');
   const scriptPath = Path.resolve(__dirname, 'runBeeNode.sh');
 
   try {
-    execSync(`chmod +x ${scriptPath}`); // Ensure the script is executable
+    execSync(`chmod +x ${scriptPath}`);
     execSync(scriptPath, { stdio: 'inherit' });
-    console.log('Bee Nodes started successfully');
+    console.debug('Bee Nodes started successfully');
   } catch (error) {
     console.error('Error starting Bee Nodes:', error);
     process.exit(1);

--- a/tests/integration/test-node-setup/jestTeardown.ts
+++ b/tests/integration/test-node-setup/jestTeardown.ts
@@ -2,13 +2,13 @@ import { execSync } from 'child_process';
 import path from 'path';
 
 export default async function globalTeardown(): Promise<void> {
-  console.log('Stopping Bee Nodes...');
+  console.debug('Stopping Bee Nodes...');
   const scriptPath = path.resolve(__dirname, 'stopBeeNode.sh');
 
   try {
-    execSync(`chmod +x ${scriptPath}`); // Ensure the script is executable
+    execSync(`chmod +x ${scriptPath}`);
     execSync(scriptPath, { stdio: 'inherit' });
-    console.log('Bee Nodes stopped successfully');
+    console.debug('Bee Nodes stopped successfully');
   } catch (error) {
     console.error('Error stopping Bee Nodes:', error);
     process.exit(1);

--- a/tests/integration/test-node-setup/runBeeNode.sh
+++ b/tests/integration/test-node-setup/runBeeNode.sh
@@ -6,6 +6,8 @@ BEE_DIR="$SCRIPT_DIR/bee-dev"
 BEE_REPO="git@github.com:Solar-Punk-Ltd/bee.git"
 BEE_BRANCH="tmp/dev-feed"
 BEE_BINARY_PATH="$BEE_DIR/dist/bee"
+BEE_URL="127.0.0.1:1633"
+OTHER_BEE_URL="127.0.0.1:1733"
 
 # Define separate log and pid files for each node.
 LOG_FILE_1733="bee_1733.log"
@@ -51,7 +53,7 @@ cd "$SCRIPT_DIR" || exit
 # --- Start Bee Node on port 1733 ---
 echo "Starting Bee node on port 1733..."
 nohup "$BEE_BINARY_PATH" dev \
-  --api-addr="127.0.0.1:1733" \
+  --api-addr="$OTHER_BEE_URL" \
   --verbosity=5 \
   --cors-allowed-origins="*" > "$LOG_FILE_1733" 2>&1 &
 BEE_PID_1733=$!
@@ -60,23 +62,23 @@ echo $BEE_PID_1733 > "$BEE_PID_FILE_1733"
 # --- Start Bee Node on port 1633 ---
 echo "Starting Bee node on port 1633..."
 nohup "$BEE_BINARY_PATH" dev \
-  --api-addr="127.0.0.1:1633" \
+  --api-addr="$BEE_URL" \
   --verbosity=5 \
   --cors-allowed-origins="*" > "$LOG_FILE_1633" 2>&1 &
 BEE_PID_1633=$!
 echo $BEE_PID_1633 > "$BEE_PID_FILE_1633"
 
 # Wait a few seconds to let both nodes initialize.
-sleep 2
+sleep 1
 
 # Health check for port 1733.
-if ! curl --silent --fail http://127.0.0.1:1733/health; then
+if ! curl --silent --fail "http://$OTHER_BEE_URL/health"; then
   echo "Bee node on port 1733 health check failed. Exiting."
   exit 1
 fi
 
 # Health check for port 1633.
-if ! curl --silent --fail http://127.0.0.1:1633/health; then
+if ! curl --silent --fail "http://$BEE_URL/health"; then
   echo "Bee node on port 1633 health check failed. Exiting."
   exit 1
 fi

--- a/tests/integration/test-node-setup/runBeeNode.sh
+++ b/tests/integration/test-node-setup/runBeeNode.sh
@@ -3,7 +3,7 @@
 # Compute the absolute directory of this script.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BEE_DIR="$SCRIPT_DIR/bee-dev"
-BEE_REPO="git@github.com:Solar-Punk-Ltd/bee.git"
+BEE_REPO="https://github.com/Solar-Punk-Ltd/bee.git"
 BEE_BRANCH="tmp/dev-feed"
 BEE_BINARY_PATH="$BEE_DIR/dist/bee"
 BEE_URL="127.0.0.1:1633"
@@ -69,18 +69,13 @@ BEE_PID_1633=$!
 echo $BEE_PID_1633 > "$BEE_PID_FILE_1633"
 
 # Wait a few seconds to let both nodes initialize.
-sleep 1
-
-# Health check for port 1733.
-if ! curl --silent --fail "http://$OTHER_BEE_URL/health"; then
-  echo "Bee node on port 1733 health check failed. Exiting."
-  exit 1
-fi
-
-# Health check for port 1633.
-if ! curl --silent --fail "http://$BEE_URL/health"; then
-  echo "Bee node on port 1633 health check failed. Exiting."
-  exit 1
-fi
+for i in {1..10}; do
+  if curl --silent --fail "http://$OTHER_BEE_URL/health" && curl --silent --fail "http://$BEE_URL/health"; then
+    echo Both Bee nodes are healthy
+    break
+  fi
+  echo "Waiting for Bee nodes…"
+  sleep 1
+done
 
 echo "Both Bee nodes are healthy and ready to process requests."

--- a/tests/integration/test-node-setup/runBeeNode.sh
+++ b/tests/integration/test-node-setup/runBeeNode.sh
@@ -25,13 +25,11 @@ fi
 cd "$BEE_DIR" || exit
 
 # Checkout the desired branch and update.
-echo "Fetching latest code..."
-git fetch origin "$BEE_BRANCH"
-git checkout "$BEE_BRANCH"
-
-LATEST_COMMIT=$(git rev-parse --short HEAD)
-echo "Latest Bee commit: $LATEST_COMMIT"
-git checkout "$LATEST_COMMIT"
+if [ "$(git branch --show-current)" != "$BEE_BRANCH" ]; then
+  echo "Switching to branch $BEE_BRANCH..."
+  git fetch origin "$BEE_BRANCH"
+  git checkout "$BEE_BRANCH"
+fi
 
 # Build the Bee binary.
 if ! make binary; then
@@ -69,7 +67,7 @@ BEE_PID_1633=$!
 echo $BEE_PID_1633 > "$BEE_PID_FILE_1633"
 
 # Wait a few seconds to let both nodes initialize.
-sleep 10
+sleep 2
 
 # Health check for port 1733.
 if ! curl --silent --fail http://127.0.0.1:1733/health; then

--- a/tests/integration/test-node-setup/stopBeeNode.sh
+++ b/tests/integration/test-node-setup/stopBeeNode.sh
@@ -3,6 +3,8 @@
 # Define pid file names and ports.
 BEE_PID_FILE_1733="bee_1733.pid"
 BEE_PID_FILE_1633="bee_1633.pid"
+LOG_FILE_1733="bee_1733.log"
+LOG_FILE_1633="bee_1633.log"
 BEE_PORT_1733=1733
 BEE_PORT_1633=1633
 
@@ -10,16 +12,21 @@ BEE_PORT_1633=1633
 stop_bee_node() {
   PID_FILE=$1
   PORT=$2
+
   if [ -f "$PID_FILE" ]; then
     BEE_PID=$(cat "$PID_FILE")
     echo "Stopping Bee node on port $PORT with PID $BEE_PID..."
     kill "$BEE_PID" 2>/dev/null
-    sleep 5
+
+    sleep 1
+
     if ps -p $BEE_PID > /dev/null; then
       echo "Force killing Bee node on port $PORT with PID $BEE_PID..."
       kill -9 "$BEE_PID"
     fi
-    rm "$PID_FILE"
+
+    rm -f "$PID_FILE"
+
     echo "Bee node on port $PORT stopped."
   else
     echo "Bee node on port $PORT is not running or PID file not found."
@@ -33,20 +40,23 @@ stop_bee_node() {
   fi
 }
 
+TMP_DIR="$(dirname "$0")"
 # Stop both Bee nodes.
-stop_bee_node "bee_1733.pid" $BEE_PORT_1733
-stop_bee_node "bee_1633.pid" $BEE_PORT_1633
+stop_bee_node "$TMP_DIR/$BEE_PID_FILE_1733" $BEE_PORT_1733
+stop_bee_node "$TMP_DIR/$BEE_PID_FILE_1633" $BEE_PORT_1633
+
+rm -f "$TMP_DIR/$LOG_FILE_1733" "$TMP_DIR/$LOG_FILE_1633"
 
 # Remove Bee repository and any associated data (if desired).
-BEE_DIR="$(dirname "$0")/bee-dev"
-BEE_DATA_DIR="$(dirname "$0")/bee-data"
-if [ -d "$BEE_DIR" ]; then
-  echo "Deleting Bee repository folder..."
-  rm -rf "$BEE_DIR"
-fi
-if [ -d "$BEE_DATA_DIR" ]; then
-  echo "Deleting Bee data directory..."
-  rm -rf "$BEE_DATA_DIR"
-fi
+# BEE_DIR="$TMP_DIR/bee-dev"
+# BEE_DATA_DIR="$TMP_DIR/bee-data"
+# if [ -d "$BEE_DIR" ]; then
+#   echo "Deleting Bee repository folder..."
+#   rm -rf "$BEE_DIR"
+# fi
+# if [ -d "$BEE_DATA_DIR" ]; then
+#   echo "Deleting Bee data directory..."
+#   rm -rf "$BEE_DATA_DIR"
+# fi
 
 echo "Cleanup completed."

--- a/tests/integration/test-node-setup/stopBeeNode.sh
+++ b/tests/integration/test-node-setup/stopBeeNode.sh
@@ -48,15 +48,15 @@ stop_bee_node "$TMP_DIR/$BEE_PID_FILE_1633" $BEE_PORT_1633
 rm -f "$TMP_DIR/$LOG_FILE_1733" "$TMP_DIR/$LOG_FILE_1633"
 
 # Remove Bee repository and any associated data (if desired).
-# BEE_DIR="$TMP_DIR/bee-dev"
-# BEE_DATA_DIR="$TMP_DIR/bee-data"
-# if [ -d "$BEE_DIR" ]; then
-#   echo "Deleting Bee repository folder..."
-#   rm -rf "$BEE_DIR"
-# fi
-# if [ -d "$BEE_DATA_DIR" ]; then
-#   echo "Deleting Bee data directory..."
-#   rm -rf "$BEE_DATA_DIR"
-# fi
+BEE_DIR="$TMP_DIR/bee-dev"
+BEE_DATA_DIR="$TMP_DIR/bee-data"
+if [ -d "$BEE_DIR" ]; then
+  echo "Deleting Bee repository folder..."
+  rm -rf "$BEE_DIR"
+fi
+if [ -d "$BEE_DATA_DIR" ]; then
+  echo "Deleting Bee data directory..."
+  rm -rf "$BEE_DATA_DIR"
+fi
 
 echo "Cleanup completed."

--- a/tests/integration/testSetupHelpers.ts
+++ b/tests/integration/testSetupHelpers.ts
@@ -1,0 +1,30 @@
+import { BatchId, BeeDev } from '@ethersphere/bee-js';
+
+import { buyStamp } from '../../src/utils/common';
+import { OWNER_STAMP_LABEL } from '../../src/utils/constants';
+import { BEE_URL, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, MOCK_SIGNER } from '../utils';
+
+let globalOwnerStamp: BatchId | null = null;
+let globalBee: BeeDev | null = null;
+
+export async function ensureOwnerStamp(): Promise<{ bee: BeeDev; ownerStamp: BatchId }> {
+  if (!globalBee) {
+    globalBee = new BeeDev(BEE_URL, { signer: MOCK_SIGNER });
+  }
+
+  if (!globalOwnerStamp) {
+    try {
+      globalOwnerStamp = await buyStamp(globalBee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
+    } catch (error: any) {
+      console.error('Failed to create/find owner stamp:', error);
+      throw error;
+    }
+  }
+
+  return { bee: globalBee, ownerStamp: globalOwnerStamp };
+}
+
+export function resetGlobalStampState(): void {
+  globalOwnerStamp = null;
+  globalBee = null;
+}

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -48,15 +48,11 @@ export async function createInitializedFileManager(
   emitter?: EventEmitter,
 ): Promise<FileManagerBase> {
   const fm = new FileManagerBase(bee, emitter);
-  verifyInit(fm.emitter);
-  await fm.initialize();
-  return fm;
-}
-
-export function verifyInit(emitter: EventEmitter): void {
-  emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, (e) => {
+  fm.emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, (e) => {
     expect(e).toEqual(true);
   });
+  await fm.initialize();
+  return fm;
 }
 
 export function createMockNodeAddresses(): NodeAddresses {

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -5,7 +5,6 @@ import {
   Bytes,
   Duration,
   EthAddress,
-  FeedIndex,
   FeedReader,
   FeedWriter,
   MantarayNode,
@@ -23,7 +22,8 @@ import { Optional } from 'cafe-utility';
 import { FileManagerBase } from '../src/fileManager';
 import { OWNER_STAMP_LABEL, SWARM_ZERO_ADDRESS } from '../src/utils/constants';
 import { EventEmitter } from '../src/utils/eventEmitter';
-import { FeedPayloadResult, FileInfo } from '../src/utils/types';
+import { FileManagerEvents } from '../src/utils/events';
+import { FileInfo } from '../src/utils/types';
 
 import { BEE_URL, MOCK_SIGNER } from './utils';
 
@@ -48,8 +48,16 @@ export async function createInitializedFileManager(
   emitter?: EventEmitter,
 ): Promise<FileManagerBase> {
   const fm = new FileManagerBase(bee, emitter);
+  verifyInit(fm.emitter);
   await fm.initialize();
   return fm;
+}
+
+export function verifyInit(emitter: EventEmitter): void {
+  emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, (e) => {
+    console.log('bagoy verifyInit: ', e);
+    expect(e).toEqual(true);
+  });
 }
 
 export function createMockNodeAddresses(): NodeAddresses {
@@ -76,14 +84,6 @@ export async function createMockFileInfo(
       reference: ref,
       historyRef: SWARM_ZERO_ADDRESS.toString(),
     },
-  };
-}
-
-export function createMockGetFeedDataResult(currentIndex = 0, nextIndex = 1): FeedPayloadResult {
-  return {
-    feedIndex: FeedIndex.fromBigInt(BigInt(currentIndex)),
-    feedIndexNext: FeedIndex.fromBigInt(BigInt(nextIndex)),
-    payload: SWARM_ZERO_ADDRESS,
   };
 }
 

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -55,7 +55,6 @@ export async function createInitializedFileManager(
 
 export function verifyInit(emitter: EventEmitter): void {
   emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, (e) => {
-    console.log('bagoy verifyInit: ', e);
     expect(e).toEqual(true);
   });
 }

--- a/tests/unit/fileManager.spec.ts
+++ b/tests/unit/fileManager.spec.ts
@@ -96,9 +96,7 @@ describe('FileManager', () => {
   describe('initialize', () => {
     it('should initialize FileManager', async () => {
       const bee = new Bee(BEE_URL, { signer: MOCK_SIGNER });
-      const eventHandler = jest.fn((input) => {
-        console.log('Input: ', input);
-      });
+      const eventHandler = jest.fn((_) => {});
       const emitter = new EventEmitterBase();
       emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, eventHandler);
       await createInitializedFileManager(bee, emitter);
@@ -107,10 +105,8 @@ describe('FileManager', () => {
     });
 
     it('should not initialize, if already initialized', async () => {
-      const logSpy = jest.spyOn(console, 'log');
-      const eventHandler = jest.fn((input) => {
-        console.log('Input: ', input);
-      });
+      const logSpy = jest.spyOn(console, 'debug');
+      const eventHandler = jest.fn((_) => {});
       const emitter = new EventEmitterBase();
       emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, eventHandler);
 
@@ -121,10 +117,8 @@ describe('FileManager', () => {
     });
 
     it('should not initialize, if currently being initialized', async () => {
-      const logSpy = jest.spyOn(console, 'log');
-      const eventHandler = jest.fn((input) => {
-        console.log('Input: ', input);
-      });
+      const logSpy = jest.spyOn(console, 'debug');
+      const eventHandler = jest.fn((_) => {});
       const emitter = new EventEmitterBase();
       emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, eventHandler);
 
@@ -428,9 +422,7 @@ describe('FileManager', () => {
     it('should send event after upload happens', async () => {
       const bee = new Bee(BEE_URL, { signer: MOCK_SIGNER });
       const emitter = new EventEmitterBase();
-      const uploadHandler = jest.fn((input) => {
-        console.log('Input: ', input);
-      });
+      const uploadHandler = jest.fn((_) => {});
 
       const fm = await createInitializedFileManager(bee, emitter);
       fm.emitter.on(FileManagerEvents.FILE_UPLOADED, uploadHandler);
@@ -471,9 +463,7 @@ describe('FileManager', () => {
 
     it('should send an event after the fileManager is initialized', async () => {
       const bee = new Bee(BEE_URL, { signer: MOCK_SIGNER });
-      const eventHandler = jest.fn((input) => {
-        console.log('Input: ', input);
-      });
+      const eventHandler = jest.fn((_) => {});
       const emitter = new EventEmitterBase();
       emitter.on(FileManagerEvents.FILEMANAGER_INITIALIZED, eventHandler);
       await createInitializedFileManager(bee, emitter);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,8 +1,7 @@
-import { BatchId, Bee, Bytes, FeedIndex, MantarayNode, PrivateKey, Topic } from '@ethersphere/bee-js';
+import { BatchId, Bee, Bytes, MantarayNode, PrivateKey } from '@ethersphere/bee-js';
 import * as fs from 'fs';
 import path from 'path';
 
-import { getFeedData } from '../src/utils/common';
 import { SWARM_ZERO_ADDRESS } from '../src/utils/constants';
 import { FileInfo, FileManager, ReferenceWithHistory, WrappedUploadResult } from '../src/utils/types';
 
@@ -76,17 +75,5 @@ export async function createWrappedData(bee: Bee, batchId: BatchId, node: Mantar
   return {
     reference: wrappedRes.reference.toString(),
     historyRef: wrappedRes.historyAddress.getOrThrow().toString(),
-  };
-}
-
-export async function getTopicNextIndex(
-  bee: Bee,
-  owner: string,
-  fi: FileInfo,
-): Promise<{ feedIndex: FeedIndex; feedIndexNext: FeedIndex }> {
-  const latest = await getFeedData(bee, new Topic(fi.topic), owner);
-  return {
-    feedIndex: latest.feedIndex,
-    feedIndexNext: latest.feedIndexNext ?? FeedIndex.fromBigInt(0n),
   };
 }


### PR DESCRIPTION
Upload now checks for the provided file reference so that it does not try to re-upload the same data. Only metadata is updated in this case with a new version.

Fix error when version is not provided in getVersion() due to feed data unwrapping.
Add FeedResultWithIndex Interface, which always provides a feedIndex and feedNextIndex.

Refactor and solve concurrency issues in integration tests.
Add new tests for versioned upload.