### PR TITLE
Adds drive handling with admin stamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ethersphere/bee-js": "^9.7.0",
-        "cafe-utility": "^31.0.0"
+        "@ethersphere/bee-js": "^10.0.0",
+        "cafe-utility": "^32.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
@@ -2588,13 +2588,14 @@
       }
     },
     "node_modules/@ethersphere/bee-js": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-9.7.0.tgz",
-      "integrity": "sha512-kA03jVgxz01TYAIKWwUQ6ob9I/hzl4XrqO48ZYaivuvMX9n+8WG1FPx+qcCUHSm6L1LBtGJ52WKnrWmdcTKWFw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-10.0.0.tgz",
+      "integrity": "sha512-udOpb05nTOWaNCGC9TNUARqkPbQNDvbtS1FKH1X15lm4bQ+yTrOn/t57TEyduPX46ol+x9zND//F7/gQXr9VBQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "axios": "^0.30.0",
-        "cafe-utility": "^28.1.0",
+        "cafe-utility": "^31.0.0",
+        "debug": "^4.4.1",
         "isomorphic-ws": "^4.0.1",
         "semver": "^7.3.5",
         "ws": "^8.7.0"
@@ -2605,9 +2606,9 @@
       }
     },
     "node_modules/@ethersphere/bee-js/node_modules/cafe-utility": {
-      "version": "28.2.0",
-      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-28.2.0.tgz",
-      "integrity": "sha512-EppX+Asq5R/3Ozn8eyPpDKVVb9q5hky3dK1gBIwIoR/LNPZJc16KoZQ9zqWNigwTLpfpg5Eyo09iq8M59moR3w==",
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-31.1.1.tgz",
+      "integrity": "sha512-1GZGghv6wi5Yfb6DGR02aIwPKH1/ny9w8nlUZM0Mo+dUf0BpmPmy9wKMZZEeaY72LPmDWQtfyoGGgaG5kINsNw==",
       "license": "MIT"
     },
     "node_modules/@ethersphere/bee-js/node_modules/semver": {
@@ -5710,9 +5711,9 @@
       "license": "MIT"
     },
     "node_modules/cafe-utility": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-31.0.0.tgz",
-      "integrity": "sha512-SBSXCnaYcgoaUxXcMFQkCoIdZuPBzxF2cl3FKxw4HpcDNtfdMQfbNYXZqV3HxP6bu6JOGkak8O93DkKojUC6Ow==",
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-32.1.0.tgz",
+      "integrity": "sha512-2e5Aax4m+184GtoGhLLGDADRYh7YQOmAjUE4pT+EcGeqGCtQKbaICKOeeUAh8XBF9D3UdultHz0jFoa6qE4Tqw==",
       "license": "MIT"
     },
     "node_modules/call-bind": {
@@ -6176,10 +6177,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -9977,7 +9977,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ethersphere/bee-js": "^9.1.0",
-        "cafe-utility": "^27.16.2"
+        "@ethersphere/bee-js": "^9.7.0",
+        "cafe-utility": "^31.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
@@ -2588,13 +2588,13 @@
       }
     },
     "node_modules/@ethersphere/bee-js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-9.1.0.tgz",
-      "integrity": "sha512-hMWScFHU5ZH4wZc6cGZsBRxxiW1uwBxhNzW5nJ/vdzwQx9/sL1zEuCBkBPrbnlfnj7/ubnDZHj93s5n0qZ64PA==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-9.7.0.tgz",
+      "integrity": "sha512-kA03jVgxz01TYAIKWwUQ6ob9I/hzl4XrqO48ZYaivuvMX9n+8WG1FPx+qcCUHSm6L1LBtGJ52WKnrWmdcTKWFw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "axios": "^0.30.0",
-        "cafe-utility": "^27.14.2",
+        "cafe-utility": "^28.1.0",
         "isomorphic-ws": "^4.0.1",
         "semver": "^7.3.5",
         "ws": "^8.7.0"
@@ -2603,6 +2603,12 @@
         "bee": "2.4.0-390a402e",
         "beeApiVersion": "7.2.0"
       }
+    },
+    "node_modules/@ethersphere/bee-js/node_modules/cafe-utility": {
+      "version": "28.2.0",
+      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-28.2.0.tgz",
+      "integrity": "sha512-EppX+Asq5R/3Ozn8eyPpDKVVb9q5hky3dK1gBIwIoR/LNPZJc16KoZQ9zqWNigwTLpfpg5Eyo09iq8M59moR3w==",
+      "license": "MIT"
     },
     "node_modules/@ethersphere/bee-js/node_modules/semver": {
       "version": "7.7.1",
@@ -5704,9 +5710,9 @@
       "license": "MIT"
     },
     "node_modules/cafe-utility": {
-      "version": "27.16.2",
-      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-27.16.2.tgz",
-      "integrity": "sha512-EUHTmBdbIT0xh56cWs+upqxmpsojqDyMJEFpV6o5eXnYqxzBpgG7QYx8er2iUy6hkl4kchEwaJ41+25Dz9syzg==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/cafe-utility/-/cafe-utility-31.0.0.tgz",
+      "integrity": "sha512-SBSXCnaYcgoaUxXcMFQkCoIdZuPBzxF2cl3FKxw4HpcDNtfdMQfbNYXZqV3HxP6bu6JOGkak8O93DkKojUC6Ow==",
       "license": "MIT"
     },
     "node_modules/call-bind": {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "homepage": "https://github.com/Solar-Punk-Ltd/file-manager-lib",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ethersphere/bee-js": "^9.1.0",
-    "cafe-utility": "^27.16.2"
+    "@ethersphere/bee-js": "^9.7.0",
+    "cafe-utility": "^31.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "homepage": "https://github.com/Solar-Punk-Ltd/file-manager-lib",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ethersphere/bee-js": "^9.7.0",
-    "cafe-utility": "^31.0.0"
+    "@ethersphere/bee-js": "^10.0.0",
+    "cafe-utility": "^32.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -775,6 +775,9 @@ export class FileManagerBase implements FileManager {
         console.debug('Error received in shared inbox: ', e.message);
         throw new SubscribtionError(e.message);
       },
+      onClose: () => {
+        console.debug('Shared inbox closed');
+      },
     });
   }
 

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -320,7 +320,7 @@ export class FileManagerBase implements FileManager {
       owner: this.signer.publicKey().address().toString(),
       redundancyLevel: uploadOptions?.redundancyLevel ?? RedundancyLevel.OFF,
       infoFeedList: [],
-      isAdmin: isAdmin ?? false,
+      isAdmin,
     };
     this.driveList.push(driveInfo);
 
@@ -364,7 +364,6 @@ export class FileManagerBase implements FileManager {
     return await downloadBrowser(Object.values(resources), this.bee.url, 'bytes');
   }
 
-  // TODO: new version needs to call handleGrantees?
   async upload(
     driveInfo: DriveInfo,
     fileOptions: FileInfoOptions,
@@ -461,6 +460,7 @@ export class FileManagerBase implements FileManager {
         topic: topic.toString(),
       });
     } else {
+      // TODO: new version needs to call handleGrantees:
       // overwrite the existing grantee reference if it exists, as they do not have access to the new version
       this.driveList[driveIndex].infoFeedList[infoIx] = {
         topic: topic.toString(),
@@ -754,11 +754,10 @@ export class FileManagerBase implements FileManager {
     }
   }
 
-  // TODO: DriveError
   async destroyDrive(drive: DriveInfo): Promise<void> {
     const adminStamp = await this.getAdminStamp();
     if (drive.isAdmin || (adminStamp && new BatchId(drive.batchId).equals(adminStamp.batchID))) {
-      throw new StampError(`Cannot destroy admin drive / stamp, batchId: ${drive.batchId.toString()}`);
+      throw new DriveError(`Cannot destroy admin drive / stamp, batchId: ${drive.batchId.toString()}`);
     }
     const driveIx = this.driveList.findIndex((d) => d.id.toString() === drive.id.toString());
     if (driveIx === -1) {

--- a/src/upload/upload.browser.ts
+++ b/src/upload/upload.browser.ts
@@ -1,10 +1,11 @@
-import { Bee, BeeRequestOptions, RedundantUploadOptions, UploadResult } from '@ethersphere/bee-js';
+import { BatchId, Bee, BeeRequestOptions, RedundantUploadOptions, UploadResult } from '@ethersphere/bee-js';
 
 import { FileInfoOptions, WrappedUploadResult } from '../utils/types';
 import { FileInfoError } from '../utils/errors';
 
 export async function uploadBrowser(
   bee: Bee,
+  batchId: string | BatchId,
   fileOptions: FileInfoOptions,
   uploadOptions?: RedundantUploadOptions,
   requestOptions?: BeeRequestOptions,
@@ -14,7 +15,7 @@ export async function uploadBrowser(
   }
 
   const uploadFilesRes = await bee.streamFiles(
-    fileOptions.batchId,
+    batchId,
     fileOptions.files,
     fileOptions.onUploadProgress,
     { ...uploadOptions, act: false },
@@ -23,7 +24,7 @@ export async function uploadBrowser(
   let uploadPreviewRes: UploadResult | undefined;
   if (fileOptions.preview) {
     uploadPreviewRes = await bee.streamFiles(
-      fileOptions.batchId,
+      batchId,
       [fileOptions.preview],
       fileOptions.onUploadProgress,
       { ...uploadOptions, act: false },
@@ -36,10 +37,5 @@ export async function uploadBrowser(
     uploadPreviewRes: uploadPreviewRes?.reference.toString(),
   };
 
-  return await bee.uploadData(
-    fileOptions.batchId,
-    JSON.stringify(wrappedData),
-    { ...uploadOptions, act: true },
-    requestOptions,
-  );
+  return await bee.uploadData(batchId, JSON.stringify(wrappedData), { ...uploadOptions, act: true }, requestOptions);
 }

--- a/src/upload/upload.browser.ts
+++ b/src/upload/upload.browser.ts
@@ -5,27 +5,27 @@ import { FileInfoError } from '../utils/errors';
 
 export async function uploadBrowser(
   bee: Bee,
-  infoOptions: FileInfoOptions,
+  fileOptions: FileInfoOptions,
   uploadOptions?: RedundantUploadOptions,
   requestOptions?: BeeRequestOptions,
 ): Promise<UploadResult> {
-  if (!infoOptions.files) {
+  if (!fileOptions.files) {
     throw new FileInfoError('Files option has to be provided.');
   }
 
   const uploadFilesRes = await bee.streamFiles(
-    infoOptions.batchId,
-    infoOptions.files,
-    infoOptions.onUploadProgress,
+    fileOptions.batchId,
+    fileOptions.files,
+    fileOptions.onUploadProgress,
     { ...uploadOptions, act: false },
     requestOptions,
   );
   let uploadPreviewRes: UploadResult | undefined;
-  if (infoOptions.preview) {
+  if (fileOptions.preview) {
     uploadPreviewRes = await bee.streamFiles(
-      infoOptions.batchId,
-      [infoOptions.preview],
-      infoOptions.onUploadProgress,
+      fileOptions.batchId,
+      [fileOptions.preview],
+      fileOptions.onUploadProgress,
       { ...uploadOptions, act: false },
       requestOptions,
     );
@@ -37,7 +37,7 @@ export async function uploadBrowser(
   };
 
   return await bee.uploadData(
-    infoOptions.batchId,
+    fileOptions.batchId,
     JSON.stringify(wrappedData),
     { ...uploadOptions, act: true },
     requestOptions,

--- a/src/upload/upload.node.ts
+++ b/src/upload/upload.node.ts
@@ -13,27 +13,27 @@ import { FileInfoOptions, WrappedUploadResult } from '../utils/types';
 
 export async function uploadNode(
   bee: Bee,
-  infoOptions: FileInfoOptions,
+  fileOptions: FileInfoOptions,
   uploadOptions?: FileUploadOptions | CollectionUploadOptions,
   requestOptions?: BeeRequestOptions,
 ): Promise<UploadResult> {
-  if (!infoOptions.path) {
+  if (!fileOptions.path) {
     throw new FileInfoError('Path option has to be provided.');
   }
 
   const uploadFilesRes = await uploadFileOrDirectory(
     bee,
-    infoOptions.batchId,
-    infoOptions.path,
+    new BatchId(fileOptions.batchId),
+    fileOptions.path,
     { ...uploadOptions, act: false },
     requestOptions,
   );
   let uploadPreviewRes: UploadResult | undefined;
-  if (infoOptions.previewPath) {
+  if (fileOptions.previewPath) {
     uploadPreviewRes = await uploadFileOrDirectory(
       bee,
-      infoOptions.batchId,
-      infoOptions.previewPath,
+      new BatchId(fileOptions.batchId),
+      fileOptions.previewPath,
       { ...uploadOptions, act: false },
       requestOptions,
     );
@@ -45,7 +45,7 @@ export async function uploadNode(
   };
 
   return await bee.uploadData(
-    infoOptions.batchId,
+    fileOptions.batchId,
     JSON.stringify(wrappedData),
     { ...uploadOptions, act: true },
     requestOptions,

--- a/src/upload/upload.node.ts
+++ b/src/upload/upload.node.ts
@@ -13,6 +13,7 @@ import { FileInfoOptions, WrappedUploadResult } from '../utils/types';
 
 export async function uploadNode(
   bee: Bee,
+  batchId: string | BatchId,
   fileOptions: FileInfoOptions,
   uploadOptions?: FileUploadOptions | CollectionUploadOptions,
   requestOptions?: BeeRequestOptions,
@@ -23,7 +24,7 @@ export async function uploadNode(
 
   const uploadFilesRes = await uploadFileOrDirectory(
     bee,
-    new BatchId(fileOptions.batchId),
+    new BatchId(batchId),
     fileOptions.path,
     { ...uploadOptions, act: false },
     requestOptions,
@@ -32,7 +33,7 @@ export async function uploadNode(
   if (fileOptions.previewPath) {
     uploadPreviewRes = await uploadFileOrDirectory(
       bee,
-      new BatchId(fileOptions.batchId),
+      new BatchId(batchId),
       fileOptions.previewPath,
       { ...uploadOptions, act: false },
       requestOptions,
@@ -44,12 +45,7 @@ export async function uploadNode(
     uploadPreviewRes: uploadPreviewRes?.reference.toString(),
   };
 
-  return await bee.uploadData(
-    fileOptions.batchId,
-    JSON.stringify(wrappedData),
-    { ...uploadOptions, act: true },
-    requestOptions,
-  );
+  return await bee.uploadData(batchId, JSON.stringify(wrappedData), { ...uploadOptions, act: true }, requestOptions);
 }
 
 async function uploadFileOrDirectory(

--- a/src/utils/asserts.ts
+++ b/src/utils/asserts.ts
@@ -1,7 +1,7 @@
-import { EthAddress, Reference, Topic } from '@ethersphere/bee-js';
+import { BatchId, EthAddress, PublicKey, Reference, Topic } from '@ethersphere/bee-js';
 import { Types } from 'cafe-utility';
 
-import { FileInfo, ShareItem, WrappedFileInfoFeed, WrappedUploadResult } from './types';
+import { DriveInfo, FileInfo, ShareItem, WrappedFileInfoFeed, WrappedUploadResult } from './types';
 
 export function isRecord(value: unknown): value is Record<string, string> {
   return Types.isStrictlyObject(value) && Object.values(value).every((v) => typeof v === 'string');
@@ -17,10 +17,13 @@ export function assertFileInfo(value: unknown): asserts value is FileInfo {
   new Reference(fi.file.reference);
   new Reference(fi.batchId);
   new Reference(fi.file.historyRef);
+  new EthAddress(fi.owner);
+  new Topic(fi.topic);
+  new PublicKey(fi.actPublisher);
 
-  if (fi.topic !== undefined) {
-    new Topic(fi.topic);
-  }
+  // if (fi.actPublisher !== undefined) {
+  //   new PublicKey(fi.actPublisher);
+  // }
 
   if (fi.customMetadata !== undefined && !isRecord(fi.customMetadata)) {
     throw new TypeError('FileInfo customMetadata has to be object!');
@@ -28,10 +31,6 @@ export function assertFileInfo(value: unknown): asserts value is FileInfo {
 
   if (fi.timestamp !== undefined && typeof fi.timestamp !== 'number') {
     throw new TypeError('timestamp property of FileInfo has to be number!');
-  }
-
-  if (fi.owner !== undefined) {
-    new EthAddress(fi.owner);
   }
 
   if (fi.name !== undefined && typeof fi.name !== 'string') {
@@ -77,6 +76,8 @@ export function assertWrappedFileInoFeed(value: unknown): asserts value is Wrapp
 
   const wmf = value as unknown as WrappedFileInfoFeed;
 
+  new Topic(wmf.topic);
+
   if (wmf.eGranteeRef !== undefined) {
     new Reference(wmf.eGranteeRef);
   }
@@ -93,5 +94,26 @@ export function asserWrappedUploadResult(value: unknown): asserts value is Wrapp
 
   if (wur.uploadPreviewRes !== undefined) {
     new Reference(wur.uploadPreviewRes);
+  }
+}
+
+export function assertDriveInfo(value: unknown): asserts value is DriveInfo {
+  if (!Types.isStrictlyObject(value)) {
+    throw new TypeError('DriveInfo has to be object!');
+  }
+
+  const di = value as unknown as DriveInfo;
+
+  new BatchId(di.batchId);
+  new EthAddress(di.owner);
+
+  assertWrappedFileInoFeed(di.infoFeedList);
+
+  if (di.name === undefined || typeof di.name !== 'string' || di.name.length === 0) {
+    throw new TypeError('name property of DriveInfo has to be string!');
+  }
+
+  if (di.redundancyLevel !== undefined && typeof di.redundancyLevel !== 'number') {
+    throw new TypeError('redundancyLevel property of DriveInfo has to be number!');
   }
 }

--- a/src/utils/asserts.ts
+++ b/src/utils/asserts.ts
@@ -45,6 +45,10 @@ export function assertFileInfo(value: unknown): asserts value is FileInfo {
   if (fi.redundancyLevel !== undefined && typeof fi.redundancyLevel !== 'number') {
     throw new TypeError('redundancyLevel property of FileInfo has to be number!');
   }
+
+  if (fi.status !== undefined && typeof fi.status !== 'string') {
+    throw new TypeError('status property of FileInfo has to be string!');
+  }
 }
 
 export function assertShareItem(value: unknown): asserts value is ShareItem {

--- a/src/utils/asserts.ts
+++ b/src/utils/asserts.ts
@@ -1,4 +1,4 @@
-import { BatchId, EthAddress, PublicKey, Reference, Topic } from '@ethersphere/bee-js';
+import { BatchId, EthAddress, Identifier, PublicKey, Reference, Topic } from '@ethersphere/bee-js';
 import { Types } from 'cafe-utility';
 
 import { DriveInfo, FileInfo, ShareItem, WrappedFileInfoFeed, WrappedUploadResult } from './types';
@@ -71,7 +71,7 @@ export function assertShareItem(value: unknown): asserts value is ShareItem {
 
 export function assertWrappedFileInoFeed(value: unknown): asserts value is WrappedFileInfoFeed {
   if (!Types.isStrictlyObject(value)) {
-    throw new TypeError('WrappedMantarayFeed has to be object!');
+    throw new TypeError('WrappedFileInfoFeed has to be object!');
   }
 
   const wmf = value as unknown as WrappedFileInfoFeed;
@@ -106,14 +106,23 @@ export function assertDriveInfo(value: unknown): asserts value is DriveInfo {
 
   new BatchId(di.batchId);
   new EthAddress(di.owner);
+  new Identifier(di.id);
 
-  assertWrappedFileInoFeed(di.infoFeedList);
+  if (di.infoFeedList !== undefined) {
+    if (!Array.isArray(di.infoFeedList)) {
+      throw new TypeError('infoFeedList property of DriveInfo has to be array!');
+    }
+
+    for (const item of di.infoFeedList) {
+      assertWrappedFileInoFeed(item);
+    }
+  }
 
   if (di.name === undefined || typeof di.name !== 'string' || di.name.length === 0) {
     throw new TypeError('name property of DriveInfo has to be string!');
   }
 
-  if (di.redundancyLevel !== undefined && typeof di.redundancyLevel !== 'number') {
+  if (di.redundancyLevel === undefined || typeof di.redundancyLevel !== 'number') {
     throw new TypeError('redundancyLevel property of DriveInfo has to be number!');
   }
 }

--- a/src/utils/asserts.ts
+++ b/src/utils/asserts.ts
@@ -21,10 +21,6 @@ export function assertFileInfo(value: unknown): asserts value is FileInfo {
   new Topic(fi.topic);
   new PublicKey(fi.actPublisher);
 
-  // if (fi.actPublisher !== undefined) {
-  //   new PublicKey(fi.actPublisher);
-  // }
-
   if (fi.customMetadata !== undefined && !isRecord(fi.customMetadata)) {
     throw new TypeError('FileInfo customMetadata has to be object!');
   }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -2,6 +2,7 @@ import {
   BatchId,
   Bee,
   BeeRequestOptions,
+  Bytes,
   DownloadOptions,
   EthAddress,
   FeedIndex,
@@ -43,11 +44,11 @@ export async function getFeedData(
   }
 }
 
-export function generateTopic(): Topic {
+export function generateRandomBytes(len: number): Bytes {
   if (isNode) {
-    return new Topic(getRandomBytesNode(Topic.LENGTH));
+    return getRandomBytesNode(len);
   }
-  return new Topic(getRandomBytesBrowser(Topic.LENGTH));
+  return getRandomBytesBrowser(len);
 }
 
 // status is undefined in the error object

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -57,7 +57,7 @@ export function isNotFoundError(error: any): boolean {
 }
 
 export async function buyStamp(bee: Bee, amount: string | bigint, depth: number, label?: string): Promise<BatchId> {
-  const stamp = (await bee.getAllPostageBatch()).find((b) => b.label === label);
+  const stamp = (await bee.getPostageBatches()).find((b) => b.label === label);
   if (stamp && stamp.usable) {
     return stamp.batchID;
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,6 +3,6 @@ import { FeedIndex, NULL_ADDRESS, Reference, Topic } from '@ethersphere/bee-js';
 export const REFERENCE_LIST_TOPIC = Topic.fromString('reference-list');
 export const SHARED_INBOX_TOPIC = Topic.fromString('shared-inbox');
 export const SHARED_WITH_ME_TOPIC = 'shared-with-me';
-export const OWNER_STAMP_LABEL = 'owner';
+export const ADMIN_STAMP_LABEL = 'admin';
 export const SWARM_ZERO_ADDRESS = new Reference(NULL_ADDRESS);
 export const FEED_INDEX_ZERO = FeedIndex.fromBigInt(0n);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,6 +4,4 @@ export const REFERENCE_LIST_TOPIC = Topic.fromString('reference-list');
 export const SHARED_INBOX_TOPIC = Topic.fromString('shared-inbox');
 export const SHARED_WITH_ME_TOPIC = 'shared-with-me';
 export const OWNER_STAMP_LABEL = 'owner';
-export const ROOT_PATH = '/';
-export const DRIVE_INFO_PATH = ROOT_PATH + 'drive-info';
 export const SWARM_ZERO_ADDRESS = new Reference(NULL_ADDRESS);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,4 +5,5 @@ export const SHARED_INBOX_TOPIC = Topic.fromString('shared-inbox');
 export const SHARED_WITH_ME_TOPIC = 'shared-with-me';
 export const OWNER_STAMP_LABEL = 'owner';
 export const ROOT_PATH = '/';
+export const DRIVE_INFO_PATH = ROOT_PATH + 'drive-info';
 export const SWARM_ZERO_ADDRESS = new Reference(NULL_ADDRESS);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,6 +10,12 @@ export class StampError extends Error {
   }
 }
 
+export class DriveError extends Error {
+  public constructor(message: string) {
+    super(message);
+  }
+}
+
 export class SignerError extends Error {
   public constructor(message: string) {
     super(message);

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -4,4 +4,6 @@ export enum FileManagerEvents {
   FILE_VERSION_RESTORED = 'file-version-restored',
   SHARE_MESSAGE_SENT = 'file-shared',
   FILEMANAGER_INITIALIZED = 'filemanager-initialized',
+  DRIVE_CREATED = 'drive-created',
+  DRIVE_DESTROYED = 'drive-destroyed',
 }

--- a/src/utils/mantaray.ts
+++ b/src/utils/mantaray.ts
@@ -20,6 +20,7 @@ export function getForksMap(root: MantarayNode, paths?: string[]): Record<string
         filteredMap[path] = nodesMap[path];
       }
     }
+
     return filteredMap;
   }
 

--- a/src/utils/mantaray.ts
+++ b/src/utils/mantaray.ts
@@ -10,17 +10,18 @@ export async function loadMantaray(
   return mantaray;
 }
 
-export function getForkAddresses(root: MantarayNode, paths?: string[]): string[] {
-  let nodes: MantarayNode[] = root.collect();
+export function getForksMap(root: MantarayNode, paths?: string[]): Record<string, string> {
+  const nodesMap: Record<string, string> = root.collectAndMap();
 
   if (paths && paths.length > 0) {
-    nodes = nodes.filter((node) => paths.includes(node.fullPathString));
+    const filteredMap: Record<string, string> = {};
+    for (const path of paths) {
+      if (path in nodesMap) {
+        filteredMap[path] = nodesMap[path];
+      }
+    }
+    return filteredMap;
   }
 
-  const addresses: string[] = [];
-  for (const node of nodes) {
-    addresses.push(new Reference(node.targetAddress).toString());
-  }
-
-  return addresses;
+  return nodesMap;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,6 +8,7 @@ import {
   FeedIndex,
   FileUploadOptions,
   GetGranteesResult,
+  Identifier,
   PublicKey,
   RedundancyLevel,
   RedundantUploadOptions,
@@ -27,6 +28,20 @@ export interface FileManager {
    * @returns A promise that resolves when the initialization is complete.
    */
   initialize(): Promise<void>;
+
+  /**
+   * Creates a new drive with the specified options.
+   * @param driveInfo - Information about the drive to be created.
+   * @returns A promise that resolves when the drive is created.
+   */
+  createDrive(
+    batchId: string | BatchId,
+    name: string,
+    uploadOptions?: RedundantUploadOptions,
+    requestOptions?: BeeRequestOptions,
+  ): Promise<void>;
+
+  getDrives(): DriveInfo[];
 
   /**
    * Uploads a file with the given options.
@@ -153,7 +168,6 @@ export interface FileInfo {
 }
 
 export interface FileInfoOptions {
-  batchId: string | BatchId;
   name: string;
   files?: File[] | FileList;
   path?: string;
@@ -166,11 +180,12 @@ export interface FileInfoOptions {
 }
 
 export interface DriveInfo {
+  id: string | Identifier;
   batchId: string | BatchId;
   owner: string | EthAddress;
   name: string;
-  infoFeedList: WrappedFileInfoFeed[];
-  redundancyLevel?: RedundancyLevel;
+  redundancyLevel: RedundancyLevel;
+  infoFeedList?: WrappedFileInfoFeed[];
 }
 
 export interface ShareItem {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -36,6 +36,7 @@ export interface FileManager {
    * @returns A promise that resolves when the upload is complete.
    */
   upload(
+    driveInfo: DriveInfo,
     infoOptions: FileInfoOptions,
     uploadOptions?: RedundantUploadOptions | FileUploadOptions | CollectionUploadOptions,
     requestOptions?: BeeRequestOptions,
@@ -60,14 +61,14 @@ export interface FileManager {
    * @param options - Optional download options for ACT.
    * @returns A promise that resolves to an array of references with paths.
    */
-  listFiles(fileInfo: FileInfo, options?: DownloadOptions): Promise<ReferenceWithPath[]>;
+  listFiles(fileInfo: FileInfo, options?: DownloadOptions): Promise<Record<string, string>>;
 
   /**
-   * Destroys a volume identified by the given batch ID.
-   * @param batchId - The ID of the batch to destroy.
-   * @returns A promise that resolves when the volume is destroyed.
+   * Destroys a drive identified by the given batch ID.
+   * @param drive - The drive to destroy.
+   * @returns A promise that resolves when the drive is destroyed.
    */
-  destroyVolume(batchId: BatchId): Promise<void>;
+  destroyDrive(drive: DriveInfo): Promise<void>;
 
   /**
    * Shares a file information with the specified recipients.
@@ -101,25 +102,21 @@ export interface FileManager {
 
   /**
    * Returns a specific version of a file.
-   * 
+   *
    * @param fi - The base FileInfo containing topic and owner fields.
    * @param version - Optional desired version slot as a FeedIndex or hex/string. If omitted, fetches latest.
    * @returns The FileInfo corresponding to the requested version, either from cache or fetched from chain.
    */
   getVersion(fileInfo: FileInfo, version?: FeedIndex): Promise<FileInfo>;
 
-
   /**
    * Restore a previous version of a file as the new “head” in your feed.
-   * 
+   *
    * @param versionToRestore - The FileInfo instance representing the version to restore.
    * @param requestOptions - Optional BeeRequestOptions for upload operations.
    * @throws FileInfoError if no versions are found on-chain.
    */
-  restoreVersion(
-    fileInfo: FileInfo,
-    requestOptions?: BeeRequestOptions
-  ): Promise<void>;
+  restoreVersion(fileInfo: FileInfo, requestOptions?: BeeRequestOptions): Promise<void>;
 
   /**
    * Retrieves a list of file information.
@@ -146,6 +143,7 @@ export interface FileInfo {
   owner: string | EthAddress;
   actPublisher: string | PublicKey;
   topic: string | Topic;
+  drive: string;
   timestamp?: number;
   shared?: boolean;
   preview?: ReferenceWithHistory;
@@ -155,7 +153,7 @@ export interface FileInfo {
 }
 
 export interface FileInfoOptions {
-  batchId: BatchId;
+  batchId: string | BatchId;
   name: string;
   files?: File[] | FileList;
   path?: string;
@@ -165,6 +163,14 @@ export interface FileInfoOptions {
   preview?: File;
   previewPath?: string;
   onUploadProgress?: (progress: UploadProgress) => void;
+}
+
+export interface DriveInfo {
+  batchId: string | BatchId;
+  owner: string | EthAddress;
+  name: string;
+  infoFeedList: WrappedFileInfoFeed[];
+  redundancyLevel?: RedundancyLevel;
 }
 
 export interface ShareItem {
@@ -181,11 +187,6 @@ export interface ReferenceWithHistory {
 export interface WrappedFileInfoFeed {
   topic: string | Topic;
   eGranteeRef?: string | Reference;
-}
-
-export interface ReferenceWithPath {
-  reference: Reference;
-  path: string;
 }
 
 export interface FileData {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -37,6 +37,7 @@ export interface FileManager {
   createDrive(
     batchId: string | BatchId,
     name: string,
+    isAdmin: boolean,
     uploadOptions?: RedundantUploadOptions,
     requestOptions?: BeeRequestOptions,
   ): Promise<void>;
@@ -196,6 +197,7 @@ export interface DriveInfo {
   owner: string | EthAddress;
   name: string;
   redundancyLevel: RedundancyLevel;
+  isAdmin: boolean;
   infoFeedList?: WrappedFileInfoFeed[];
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -200,13 +200,12 @@ export interface FileInfo {
 }
 
 export interface PartialFileInfo
-  extends Omit<FileInfo, 'owner' | 'actPublisher' | 'file' | 'topic' | 'driveId' | 'batchId'> {
-  owner?: string | EthAddress;
-  actPublisher?: string | PublicKey;
+  extends Omit<
+    FileInfo,
+    'owner' | 'actPublisher' | 'file' | 'topic' | 'driveId' | 'batchId' | 'redundancyLevel' | 'status'
+  > {
   file?: ReferenceWithHistory;
   topic?: string | Topic;
-  driveId?: string | Identifier;
-  batchId?: string | BatchId;
 }
 
 export interface FileInfoOptions {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -41,6 +41,10 @@ export interface FileManager {
     requestOptions?: BeeRequestOptions,
   ): Promise<void>;
 
+  /**
+   * Retrieves a list of drives.
+   * @returns A list of DriveInfo objects representing the drives.
+   */
   getDrives(): DriveInfo[];
 
   /**
@@ -158,7 +162,7 @@ export interface FileInfo {
   owner: string | EthAddress;
   actPublisher: string | PublicKey;
   topic: string | Topic;
-  drive: string;
+  driveId: string;
   timestamp?: number;
   shared?: boolean;
   preview?: ReferenceWithHistory;

--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -16,7 +16,7 @@ import path from 'path';
 import { FileManagerBase } from '../../src/fileManager';
 import { buyStamp, getFeedData } from '../../src/utils/common';
 import { FEED_INDEX_ZERO, REFERENCE_LIST_TOPIC, SWARM_ZERO_ADDRESS } from '../../src/utils/constants';
-import { FileError, FileInfoError, GranteeError, StampError } from '../../src/utils/errors';
+import { DriveError, FileError, FileInfoError, GranteeError, StampError } from '../../src/utils/errors';
 import { FileManagerEvents } from '../../src/utils/events';
 import { DriveInfo, FileInfo, FileStatus } from '../../src/utils/types';
 import { createInitializedFileManager } from '../mockHelpers';
@@ -256,7 +256,7 @@ describe('FileManager drive handling', () => {
         redundancyLevel: RedundancyLevel.OFF,
         isAdmin: false,
       }),
-    ).rejects.toThrow(new StampError(`Cannot destroy admin drive / stamp, batchId: ${ownerStampId!.toString()}`));
+    ).rejects.toThrow(new DriveError(`Cannot destroy admin drive / stamp, batchId: ${ownerStampId!.toString()}`));
 
     await expect(
       fileManager.destroyDrive({
@@ -268,7 +268,7 @@ describe('FileManager drive handling', () => {
         isAdmin: true,
       }),
     ).rejects.toThrow(
-      new StampError(`Cannot destroy admin drive / stamp, batchId: ${new BatchId('6789'.repeat(16)).toString()}`),
+      new DriveError(`Cannot destroy admin drive / stamp, batchId: ${new BatchId('6789'.repeat(16)).toString()}`),
     );
   });
 

--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -786,7 +786,7 @@ describe('FileManager file operations', () => {
 
     testFilePath = path.join(__dirname, '../fixtures', TEST_NAME);
     fs.writeFileSync(testFilePath, 'file ops content');
-    await fileManager.upload(drive, { info: { batchId, name: TEST_NAME }, path: testFilePath });
+    await fileManager.upload(drive, { info: { name: TEST_NAME }, path: testFilePath });
 
     testFi = fileManager.fileInfoList.find((fi) => fi.name === TEST_NAME)!;
     expect(testFi).toBeDefined();
@@ -840,7 +840,7 @@ describe('FileManager file operations', () => {
 
   it('should never duplicate FileInfo entries when trashing/recovering', async () => {
     const fp = path.join(__dirname, '../fixtures', TEST_NAME);
-    await fileManager.upload(drive, { info: { batchId, name: TEST_NAME }, path: fp });
+    await fileManager.upload(drive, { info: { name: TEST_NAME }, path: fp });
 
     const freshFi = fileManager.fileInfoList.find((fi) => fi.name === TEST_NAME)!;
     const topic = freshFi.topic.toString();

--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -135,7 +135,7 @@ describe('FileManager initialization', () => {
 
     const batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'initstamp');
 
-    await fileManager.createDrive(batchId, 'initialization');
+    await fileManager.createDrive(batchId, 'initialization', false);
     const tmpDrive = fileManager.getDrives().find((d) => d.name === 'initialization');
     expect(tmpDrive).toBeDefined();
     drive = tmpDrive!;
@@ -236,7 +236,7 @@ describe('FileManager drive handling', () => {
       driveId = driveInfo.id.toString();
     });
 
-    await fileManager.createDrive(batchId, 'Test Drive');
+    await fileManager.createDrive(batchId, 'Test Drive', false);
     const drives = fileManager.getDrives();
     expect(drives.length).toBeGreaterThanOrEqual(1);
     const testDrive = drives.find((d) => d.name === 'Test Drive');
@@ -246,7 +246,7 @@ describe('FileManager drive handling', () => {
     expect(fileManager.fileInfoList.filter((fi) => fi.driveId === driveId)).toHaveLength(0);
   });
 
-  it('should throw an error when trying to destroy the owner stamp', async () => {
+  it('should throw an error when trying to destroy the admin drive/ stamp', async () => {
     await expect(
       fileManager.destroyDrive({
         batchId: ownerStampId!.toString(),
@@ -254,14 +254,28 @@ describe('FileManager drive handling', () => {
         name: 'Owner Drive',
         owner: MOCK_SIGNER.publicKey().address().toString(),
         redundancyLevel: RedundancyLevel.OFF,
+        isAdmin: false,
       }),
-    ).rejects.toThrow(new StampError(`Cannot destroy owner stamp, batchId: ${ownerStampId!.toString()}`));
+    ).rejects.toThrow(new StampError(`Cannot destroy admin drive / stamp, batchId: ${ownerStampId!.toString()}`));
+
+    await expect(
+      fileManager.destroyDrive({
+        batchId: new BatchId('6789'.repeat(16)).toString(),
+        id: 'mockID',
+        name: 'Owner Drive',
+        owner: MOCK_SIGNER.publicKey().address().toString(),
+        redundancyLevel: RedundancyLevel.OFF,
+        isAdmin: true,
+      }),
+    ).rejects.toThrow(
+      new StampError(`Cannot destroy admin drive / stamp, batchId: ${new BatchId('6789'.repeat(16)).toString()}`),
+    );
   });
 
   // todo: not possible to test with devnode: gives 501
   // it('should destroy the given drive', async () => {
   //   const batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'toDestroyBatch');
-  //   await fileManager.createDrive(batchId, 'Drive to destroy');
+  //   await fileManager.createDrive(batchId, 'Drive to destroy', false);
   //   const initialDrivesLength = fileManager.getDrives().length;
 
   //   const driveToDestroy = fileManager.getDrives().find((d) => d.name === 'Drive to destroy');
@@ -303,7 +317,7 @@ describe('FileManager listFiles', () => {
     fileManager = await createInitializedFileManager(bee);
     actPublisher = (await bee.getNodeAddresses())!.publicKey;
 
-    await fileManager.createDrive(batchId, 'listFiles');
+    await fileManager.createDrive(batchId, 'listFiles', false);
     const tmpDrive = fileManager.getDrives().find((d) => d.name === 'listFiles');
     expect(tmpDrive).toBeDefined();
     drive = tmpDrive!;
@@ -464,7 +478,7 @@ describe('FileManager upload', () => {
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'uploadIntegrationStamp');
     fileManager = await createInitializedFileManager(bee);
 
-    await fileManager.createDrive(batchId, 'upload');
+    await fileManager.createDrive(batchId, 'upload', false);
     const tmpDrive = fileManager.getDrives().find((d) => d.name === 'upload');
     expect(tmpDrive).toBeDefined();
     drive = tmpDrive!;
@@ -661,7 +675,7 @@ describe('FileManager download', () => {
     fileManager = await createInitializedFileManager(bee);
     actPublisher = (await bee.getNodeAddresses())!.publicKey;
 
-    await fileManager.createDrive(batchId, 'download');
+    await fileManager.createDrive(batchId, 'download', false);
     const tmpDrive = fileManager.getDrives().find((d) => d.name === 'download');
     expect(tmpDrive).toBeDefined();
     drive = tmpDrive!;
@@ -773,7 +787,7 @@ describe('FileManager version control', () => {
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'versioningStamp');
     fileManager = await createInitializedFileManager(bee);
 
-    await fileManager.createDrive(batchId, 'versioncontrol');
+    await fileManager.createDrive(batchId, 'versioncontrol', false);
     const tmpDrive = fileManager.getDrives().find((d) => d.name === 'versioncontrol');
     expect(tmpDrive).toBeDefined();
     drive = tmpDrive!;
@@ -1065,7 +1079,7 @@ describe('FileManager End-to-End User Workflow', () => {
     actPublisher = (await bee.getNodeAddresses())!.publicKey;
 
     batchId = await buyStamp(bee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, 'e2eStamp');
-    await fileManager.createDrive(batchId, 'e2e');
+    await fileManager.createDrive(batchId, 'e2e', false);
     const tmpDrive = fileManager.getDrives().find((d) => d.name === 'e2e');
     expect(tmpDrive).toBeDefined();
     drive = tmpDrive!;

--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -242,7 +242,7 @@ describe('FileManager drive handling', () => {
     expect(testDrive).toBeDefined();
     expect(driveId).toBeDefined();
     expect(testDrive?.id).toBe(driveId);
-    expect(fileManager.fileInfoList.filter((fi) => fi.drive === driveId)).toHaveLength(0);
+    expect(fileManager.fileInfoList.filter((fi) => fi.driveId === driveId)).toHaveLength(0);
   });
 
   it('should throw an error when trying to destroy the owner stamp', async () => {
@@ -984,11 +984,11 @@ describe('FileManager End-to-End User Workflow', () => {
     const singleFilePath = path.join(tempBaseDir, 'initial.txt');
     fs.writeFileSync(singleFilePath, 'Hello, this is the initial file.');
     await fileManager.upload(drive, { path: singleFilePath, name: path.basename(singleFilePath) });
-    let fileInfos = fileManager.fileInfoList.filter((fi) => fi.drive === drive.id.toString());
+    let fileInfos = fileManager.fileInfoList.filter((fi) => fi.driveId === drive.id.toString());
     expect(fileInfos.find((fi) => fi.name === path.basename(singleFilePath))).toBeDefined();
 
     fileInfos.forEach((fi) => {
-      expect(fi.drive).toBe(drive.id.toString());
+      expect(fi.driveId).toBe(drive.id.toString());
       expect(fi.batchId).toBe(drive.batchId.toString());
       expect(fi.redundancyLevel).toBe(drive.redundancyLevel);
     });
@@ -1002,12 +1002,12 @@ describe('FileManager End-to-End User Workflow', () => {
     fs.mkdirSync(assetsFolder, { recursive: true });
     fs.writeFileSync(path.join(assetsFolder, 'image.png'), 'Fake image content');
     await fileManager.upload(drive, { path: projectFolder, name: path.basename(projectFolder) });
-    fileInfos = fileManager.fileInfoList.filter((fi) => fi.drive === drive.id.toString());
+    fileInfos = fileManager.fileInfoList.filter((fi) => fi.driveId === drive.id.toString());
     const projectInfo = fileInfos.find((fi) => fi.name === path.basename(projectFolder))!;
     expect(projectInfo).toBeDefined();
 
     fileInfos.forEach((fi) => {
-      expect(fi.drive).toBe(drive.id.toString());
+      expect(fi.driveId).toBe(drive.id.toString());
       expect(fi.batchId).toBe(drive.batchId.toString());
       expect(fi.redundancyLevel).toBe(drive.redundancyLevel);
     });
@@ -1037,7 +1037,7 @@ describe('FileManager End-to-End User Workflow', () => {
     const singleFilePath = path.join(tempBaseDir, 'initial.txt');
     fs.writeFileSync(singleFilePath, 'Hello, this is the initial file.');
     await fileManager.upload(drive, { path: singleFilePath, name: path.basename(singleFilePath) });
-    let fileInfos = fileManager.fileInfoList.filter((fi) => fi.drive === drive.id.toString());
+    let fileInfos = fileManager.fileInfoList.filter((fi) => fi.driveId === drive.id.toString());
     expect(fileInfos.find((fi) => fi.name === path.basename(singleFilePath))).toBeDefined();
 
     // Step 2: Upload original project folder.
@@ -1049,12 +1049,12 @@ describe('FileManager End-to-End User Workflow', () => {
     fs.mkdirSync(assetsFolder, { recursive: true });
     fs.writeFileSync(path.join(assetsFolder, 'image.png'), 'Fake image content');
     await fileManager.upload(drive, { path: projectFolder, name: path.basename(projectFolder) });
-    fileInfos = fileManager.fileInfoList.filter((fi) => fi.drive === drive.id.toString());
+    fileInfos = fileManager.fileInfoList.filter((fi) => fi.driveId === drive.id.toString());
     const projectInfo = fileInfos.find((fi) => fi.name === path.basename(projectFolder));
     expect(projectInfo).toBeDefined();
 
     fileInfos.forEach((fi) => {
-      expect(fi.drive).toBe(drive.id.toString());
+      expect(fi.driveId).toBe(drive.id.toString());
       expect(fi.batchId).toBe(drive.batchId.toString());
       expect(fi.redundancyLevel).toBe(drive.redundancyLevel);
     });
@@ -1074,12 +1074,12 @@ describe('FileManager End-to-End User Workflow', () => {
     fs.writeFileSync(path.join(nestedFolder, 'subdoc.txt'), 'Nested document content');
     await new Promise((resolve) => setTimeout(resolve, 1000));
     await fileManager.upload(drive, { path: projectFolderNew, name: path.basename(projectFolderNew) });
-    fileInfos = fileManager.fileInfoList.filter((fi) => fi.drive === drive.id.toString());
+    fileInfos = fileManager.fileInfoList.filter((fi) => fi.driveId === drive.id.toString());
     const newVersionInfo = fileInfos.find((fi) => fi.name === path.basename(projectFolderNew));
     expect(newVersionInfo).toBeDefined();
 
     fileInfos.forEach((fi) => {
-      expect(fi.drive).toBe(drive.id.toString());
+      expect(fi.driveId).toBe(drive.id.toString());
       expect(fi.batchId).toBe(drive.batchId.toString());
       expect(fi.redundancyLevel).toBe(drive.redundancyLevel);
     });

--- a/tests/integration/testSetupHelpers.ts
+++ b/tests/integration/testSetupHelpers.ts
@@ -1,7 +1,7 @@
 import { BatchId, BeeDev } from '@ethersphere/bee-js';
 
 import { buyStamp } from '../../src/utils/common';
-import { OWNER_STAMP_LABEL } from '../../src/utils/constants';
+import { ADMIN_STAMP_LABEL } from '../../src/utils/constants';
 import { BEE_URL, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, MOCK_SIGNER } from '../utils';
 
 let globalOwnerStamp: BatchId | null = null;
@@ -14,7 +14,7 @@ export async function ensureOwnerStamp(): Promise<{ bee: BeeDev; ownerStamp: Bat
 
   if (!globalOwnerStamp) {
     try {
-      globalOwnerStamp = await buyStamp(globalBee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, OWNER_STAMP_LABEL);
+      globalOwnerStamp = await buyStamp(globalBee, DEFAULT_BATCH_AMOUNT, DEFAULT_BATCH_DEPTH, ADMIN_STAMP_LABEL);
     } catch (error: any) {
       console.error('Failed to create/find owner stamp:', error);
       throw error;

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -8,11 +8,13 @@ import {
   FeedIndex,
   FeedReader,
   FeedWriter,
+  Identifier,
   MantarayNode,
   NodeAddresses,
   NumberString,
   PeerAddress,
   PublicKey,
+  RedundancyLevel,
   Reference,
   Size,
   Topic,
@@ -23,7 +25,7 @@ import { Optional } from 'cafe-utility';
 import { FileManagerBase } from '../src/fileManager';
 import { OWNER_STAMP_LABEL, SWARM_ZERO_ADDRESS } from '../src/utils/constants';
 import { EventEmitter } from '../src/utils/eventEmitter';
-import { FeedPayloadResult, FileInfo } from '../src/utils/types';
+import { DriveInfo, FeedPayloadResult, FileInfo } from '../src/utils/types';
 
 import { BEE_URL, MOCK_SIGNER } from './utils';
 
@@ -67,15 +69,32 @@ export async function createMockFileInfo(
   ref: string = SWARM_ZERO_ADDRESS.toString(),
 ): Promise<FileInfo> {
   return {
-    batchId: new BatchId(MOCK_BATCH_ID),
+    batchId: MOCK_BATCH_ID,
     name: 'john doe',
     topic: Topic.fromString('1'),
+    drive: Identifier.fromString('123').toString(),
     owner: MOCK_SIGNER.publicKey().address().toString(),
     actPublisher: (await bee.getNodeAddresses()).publicKey.toCompressedHex(),
     file: {
       reference: ref,
       historyRef: SWARM_ZERO_ADDRESS.toString(),
     },
+  };
+}
+
+export function createMockDriveInfo(): DriveInfo {
+  return {
+    id: Identifier.fromString('123'),
+    batchId: MOCK_BATCH_ID,
+    owner: MOCK_SIGNER.publicKey().address().toString(),
+    name: 'Test Drive',
+    redundancyLevel: RedundancyLevel.MEDIUM,
+    infoFeedList: [
+      {
+        topic: Topic.fromString('1'),
+        eGranteeRef: SWARM_ZERO_ADDRESS.toString(),
+      },
+    ],
   };
 }
 

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -72,7 +72,7 @@ export async function createMockFileInfo(
     batchId: MOCK_BATCH_ID,
     name: 'john doe',
     topic: Topic.fromString('1'),
-    drive: Identifier.fromString('123').toString(),
+    driveId: Identifier.fromString('123').toString(),
     owner: MOCK_SIGNER.publicKey().address().toString(),
     actPublisher: (await bee.getNodeAddresses()).publicKey.toCompressedHex(),
     file: {

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -22,7 +22,7 @@ import {
 import { Optional } from 'cafe-utility';
 
 import { FileManagerBase } from '../src/fileManager';
-import { OWNER_STAMP_LABEL, SWARM_ZERO_ADDRESS } from '../src/utils/constants';
+import { ADMIN_STAMP_LABEL, SWARM_ZERO_ADDRESS } from '../src/utils/constants';
 import { EventEmitter } from '../src/utils/eventEmitter';
 import { FileManagerEvents } from '../src/utils/events';
 import { DriveInfo, FileInfo } from '../src/utils/types';
@@ -98,6 +98,7 @@ export function createMockDriveInfo(): DriveInfo {
         eGranteeRef: SWARM_ZERO_ADDRESS.toString(),
       },
     ],
+    isAdmin: false,
   };
 }
 
@@ -207,7 +208,7 @@ export function loadStampListMock(): jest.SpyInstance {
       utilization: 5,
       usable: true,
       usageText: '2%',
-      label: OWNER_STAMP_LABEL,
+      label: ADMIN_STAMP_LABEL,
       depth: 22,
       amount: '990' as NumberString,
       bucketDepth: 30,

--- a/tests/mockHelpers.ts
+++ b/tests/mockHelpers.ts
@@ -153,7 +153,7 @@ export function createUploadDataSpy(char: string): jest.SpyInstance {
 }
 
 export function loadStampListMock(): jest.SpyInstance {
-  return jest.spyOn(Bee.prototype, 'getAllPostageBatch').mockResolvedValue([
+  return jest.spyOn(Bee.prototype, 'getPostageBatches').mockResolvedValue([
     {
       batchID: new BatchId('1234'.repeat(16)),
       utilization: 2,


### PR DESCRIPTION
Rename volume to drive.
Save the list of drives instead of listing the local stamps
Add DriveInfo interface and save it in the new state.
Assign the same redundancyLevel to all files on the drive and link them to the drives.
Adjust and add new IT, UT accordingly. 
Fix destroyDrive and forgetFile  