### PR TITLE
Fix: Remove ACT headers for Upload Data

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -318,11 +318,9 @@ export class FileManagerBase implements FileManager {
     uploadOptions?: RedundantUploadOptions | FileUploadOptions | CollectionUploadOptions,
     requestOptions?: BeeRequestOptions,
   ): Promise<void> {
-    if (
-      (infoOptions.info.topic && !uploadOptions?.actHistoryAddress) ||
-      (!infoOptions.info.topic && uploadOptions?.actHistoryAddress)
-    ) {
-      throw new FileInfoError('Options topic and historyRef have to be provided at the same time.');
+    if (uploadOptions && uploadOptions.actHistoryAddress) {
+      // Remove ACT for file data upload
+      delete (uploadOptions as any).actHistoryAddress
     }
 
     if (!this.nodeAddresses) {
@@ -414,7 +412,6 @@ export class FileManagerBase implements FileManager {
     let feedData: FeedResultWithIndex;
     let unwrap = true;
     if (!version) {
-      // Note: feedReader.download() unwraps the data if version is undefined
       feedData = await getFeedData(this.bee, topic, fi.owner);
       unwrap = false;
     } else {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -320,7 +320,7 @@ export class FileManagerBase implements FileManager {
   ): Promise<void> {
     if (uploadOptions && uploadOptions.actHistoryAddress) {
       // Remove ACT for file data upload
-      delete (uploadOptions as any).actHistoryAddress
+      delete (uploadOptions as RedundantUploadOptions).actHistoryAddress
     }
 
     if (!this.nodeAddresses) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
-export type { FileInfo, FileManager, FileInfoOptions, ShareItem, UploadProgress } from './types';
+export type { FileInfo, FileManager, FileInfoOptions, ReferenceWithPath, ShareItem, UploadProgress } from './types';
+export type { FileStatus } from './types';
 export { FileManagerEvents } from './events';
 export { type EventEmitter, EventEmitterBase } from './eventEmitter';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -127,7 +127,7 @@ export interface FileManager {
    * @param version - Optional desired version slot as a FeedIndex or hex/string. If omitted, fetches latest.
    * @returns The FileInfo corresponding to the requested version, either cached or fetched.
    */
-  getVersion(fileInfo: FileInfo, version?: FeedIndex): Promise<FileInfo>;
+  getVersion(fileInfo: FileInfo, version?: string | FeedIndex): Promise<FileInfo>;
 
   /**
    * Restore a previous version of a file as the new “head” in your feed.

--- a/tests/integration/fileManager.spec.ts
+++ b/tests/integration/fileManager.spec.ts
@@ -3,9 +3,9 @@ import * as fs from 'fs';
 import path from 'path';
 
 import { FileManagerBase } from '../../src/fileManager';
-import { buyStamp, getFeedData } from '../../src/utils/common';
+import { buyStamp, generateTopic, getFeedData } from '../../src/utils/common';
 import { FEED_INDEX_ZERO, REFERENCE_LIST_TOPIC, SWARM_ZERO_ADDRESS } from '../../src/utils/constants';
-import { FileError, FileInfoError, GranteeError, StampError } from '../../src/utils/errors';
+import { FileError, GranteeError, StampError } from '../../src/utils/errors';
 import { FileManagerEvents } from '../../src/utils/events';
 import { FileInfo, FileStatus } from '../../src/utils/types';
 import { createInitializedFileManager } from '../mockHelpers';
@@ -479,18 +479,18 @@ describe('FileManager upload', () => {
     fs.rmSync(previewDir, { recursive: true, force: true });
   });
 
-  it('should throw an error if topic and historyRef are not provided together', async () => {
+  it('allows content upload with a provided topic and no historyRef (ACT ignored for bytes)', async () => {
+    const validTopic = generateTopic().toString();
     await expect(
       fileManager.upload({
         info: {
           batchId,
-
           name: path.basename(tempUploadDir),
-          topic: 'someInfoTopic',
+          topic: validTopic,
         },
         path: tempUploadDir,
       }),
-    ).rejects.toThrow(new FileInfoError('Options topic and historyRef have to be provided at the same time.'));
+    ).resolves.toBeUndefined();
   });
 
   it('should upload a single file and update the file info list', async () => {

--- a/tests/unit/fileManager.spec.ts
+++ b/tests/unit/fileManager.spec.ts
@@ -166,7 +166,7 @@ describe('FileManager', () => {
 
       await fm.download(mockFi, ['/root/2.txt']);
 
-      expect(downloadDataSpy).toHaveBeenCalledWith('2'.repeat(64), undefined);
+      expect(downloadDataSpy).toHaveBeenCalledWith('2'.repeat(64));
     });
 
     it('should call download for all of forks', async () => {

--- a/tests/unit/fileManager.spec.ts
+++ b/tests/unit/fileManager.spec.ts
@@ -166,7 +166,7 @@ describe('FileManager', () => {
 
       await fm.download(mockFi, ['/root/2.txt']);
 
-      expect(downloadDataSpy).toHaveBeenCalledWith('2'.repeat(64));
+      expect(downloadDataSpy).toHaveBeenCalledWith('2'.repeat(64), undefined);
     });
 
     it('should call download for all of forks', async () => {
@@ -246,19 +246,26 @@ describe('FileManager', () => {
       expect(uploadFileOrDirectoryPreviewSpy).toHaveBeenCalled();
     });
 
-    it('should throw error if infoTopic and historyRef are not provided at the same time', async () => {
+    it('allows content upload with a provided topic (no historyRef) and ignores ACT for bytes', async () => {
       const fm = await createInitializedFileManager();
-
-      await expect(async () => {
-        await fm.upload({
+      createUploadFilesFromDirectorySpy('1');
+      createUploadFileSpy('2');
+      createUploadDataSpy('3');
+      createUploadDataSpy('4');
+      createMockFeedWriter('5');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
+      const { generateTopic } = require('../../src/utils/common');
+      const validTopic = generateTopic().toString();
+      await expect(
+        fm.upload({
           info: {
             batchId: new BatchId(MOCK_BATCH_ID),
             name: 'tests',
-            topic: 'topic',
+            topic: validTopic,
           },
           path: './tests',
-        });
-      }).rejects.toThrow('Options topic and historyRef have to be provided at the same time.');
+        }),
+      ).resolves.toBeUndefined();
     });
 
     it('should not add duplicate entries when re-uploading same topic', async () => {


### PR DESCRIPTION
🔖 Title
Remove ACT handling for Uploading Data for new versions of existing files  

📝 Overview
This change involves remove the ACT headers from upload options for the files

🔗 Related Issues

🧪 How Has This Been Tested?
✅ Manually tested with a mocked Bee client

✅ Checklist
✅ My code follows the project’s style guide
✅ I have performed a self-review of my code
✅ I have commented my code where necessary
✅ I have added tests that prove my fix/feature works
✅ All new and existing tests pass locally