### PR TITLE
fix/spdv 801-2 admin stamp capacity check when creating drives

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -28,7 +28,7 @@ import {
   ADMIN_STAMP_LABEL,
   FILEMANAGER_STATE_TOPIC,
   SWARM_ZERO_ADDRESS,
-   MINIMUM_ADMIN_CAPACITY_BYTES,
+  MINIMUM_ADMIN_CAPACITY_BYTES,
 } from './utils/constants';
 import {
   AdminStampCapacityError,

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -28,6 +28,7 @@ import {
   ADMIN_STAMP_LABEL,
   FILEMANAGER_STATE_TOPIC,
   SWARM_ZERO_ADDRESS,
+   MINIMUM_ADMIN_CAPACITY_BYTES,
 } from './utils/constants';
 import {
   AdminStampCapacityError,
@@ -742,8 +743,11 @@ export class FileManagerBase implements FileManager {
       throw new StampError('Admin stamp not found');
     }
 
-    if (!adminStamp.usable || adminStamp.remainingSize.toBytes() <= 0) {
-      throw new AdminStampCapacityError('Admin drive capacity is full. Please top up the admin drive.');
+    if (!adminStamp.usable || adminStamp.remainingSize.toBytes() < MINIMUM_ADMIN_CAPACITY_BYTES) {
+      throw new AdminStampCapacityError(
+        `Admin drive capacity too low. Minimum required: ${MINIMUM_ADMIN_CAPACITY_BYTES} bytes, ` +
+          `Available: ${adminStamp.remainingSize.toBytes()} bytes. Please top up the admin drive.`,
+      );
     }
 
     try {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,3 +6,4 @@ export const SHARED_WITH_ME_TOPIC = 'shared-with-me';
 export const ADMIN_STAMP_LABEL = 'admin';
 export const SWARM_ZERO_ADDRESS = new Reference(NULL_ADDRESS);
 export const FEED_INDEX_ZERO = FeedIndex.fromBigInt(0n);
+export const MINIMUM_ADMIN_CAPACITY_BYTES = 1024;

--- a/tests/unit/fileManager.spec.ts
+++ b/tests/unit/fileManager.spec.ts
@@ -7,6 +7,7 @@ import {
   MantarayNode,
   RedundancyLevel,
   Reference,
+  Size,
   Topic,
 } from '@ethersphere/bee-js';
 
@@ -981,6 +982,72 @@ describe('FileManager', () => {
       await createInitializedFileManager(bee, MOCK_BATCH_ID, emitter);
 
       expect(eventHandler).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Admin Capacity Check', () => {
+    it('should return canCreate: true when admin stamp has sufficient capacity', async () => {
+      const fm = await createInitializedFileManager();
+      
+      const result = fm.canCreateDrive();
+      
+      expect(result.canCreate).toBe(true);
+      expect(result.availableBytes).toBeGreaterThan(0);
+      expect(result.requiredBytes).toBeGreaterThan(0);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should return canCreate: false when admin stamp is not found', async () => {
+      const bee = new Bee(BEE_URL, { signer: DEFAULT_MOCK_SIGNER });
+      const fm = new FileManagerBase(bee);
+      await fm.initialize();
+      
+      const result = fm.canCreateDrive();
+      
+      expect(result.canCreate).toBe(false);
+      expect(result.availableBytes).toBe(0);
+      expect(result.requiredBytes).toBe(0);
+      expect(result.message).toBe('Admin stamp not found');
+    });
+
+    it('should return canCreate: false when admin stamp is not usable', async () => {
+      const fm = await createInitializedFileManager();
+      
+      // @ts-expect-error accessing private property for testing
+      fm._adminStamp = {
+        ...mockPostageBatch,
+        batchID: new BatchId(MOCK_BATCH_ID),
+        label: ADMIN_STAMP_LABEL,
+        usable: false,
+        remainingSize: Size.fromGigabytes(100),
+      };
+      
+      const result = fm.canCreateDrive();
+      
+      expect(result.canCreate).toBe(false);
+      expect(result.message).toBe('Admin stamp is not usable');
+    });
+
+    it('should return canCreate: false when admin stamp has insufficient capacity', async () => {
+      const fm = await createInitializedFileManager();
+      
+      // @ts-expect-error accessing private property for testing
+      fm._adminStamp = {
+        ...mockPostageBatch,
+        batchID: new BatchId(MOCK_BATCH_ID),
+        label: ADMIN_STAMP_LABEL,
+        usable: true,
+        remainingSize: Size.fromBytes(100),
+      };
+      
+      const result = fm.canCreateDrive();
+      
+      expect(result.canCreate).toBe(false);
+      expect(result.availableBytes).toBe(100);
+      expect(result.requiredBytes).toBeGreaterThan(100);
+      expect(result.message).toContain('Insufficient capacity');
+      expect(result.message).toContain('Required:');
+      expect(result.message).toContain('Available:');
     });
   });
 });


### PR DESCRIPTION
🔖 Title
Fix part 2: Admin stamp capacity check when creating drives

📝 Description
This PR is a continuation on https://github.com/Solar-Punk-Ltd/file-manager-lib/pull/34 to add tests and a capacity check minimum threshold

Changes

- New capacity validation threshold of 1 kb instead of 0 kb.
- Unit and integration tests

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-801

🧪 How Has This Been Tested?
✅ Manually tested with Chrome

✅ Checklist
✅ I have performed a self-review of my code