### PR TITLE
v2/api-file-read: implement downloadFile(s), get and restore file version

### DIFF
--- a/changelog/v2-api-file-read.md
+++ b/changelog/v2-api-file-read.md
@@ -7,10 +7,12 @@ method was modified — only imports were added.
 ## Added — public methods
 
 - **`downloadFile(fileRecord, options?, requestOptions?)`** — convenience wrapper: downloads a single caller-held record
-  via `downloadFiles` and returns its one result.
+  via `downloadFiles` and returns its `DownloadResult`, **throwing `FileError`** if that download did not succeed (so the
+  `Promise<DownloadResult>` contract is honored). Mirrors `uploadFile`'s singular-throws shape.
 - **`downloadFiles(fileRecords, options?, requestOptions?)`** — downloads exactly the passed records with no drive
   traversal or re-resolution (caller owns record currency). Maps each record to a `DownloadResource` and delegates to
-  transport `processDownload`.
+  transport `processDownload`. Returns a partial-tolerant `DownloadFilesResult { succeeded, failed }`, mirroring
+  `uploadFiles` — per-file failures land in `failed` instead of being dropped.
 - **`getFileVersion(fr, version?, requestOptions?)`** — resolves a specific version from the file's own feed
   (short-circuits to the in-memory head when the cached version matches), returning the `FileRecord` for that slot.
   Read-only — no persistence.
@@ -22,7 +24,9 @@ method was modified — only imports were added.
 
 Content download is not re-implemented here. `downloadFiles` builds `DownloadResource[]` (from `./types/v2/download`)
 and calls transport's `processDownload` (from `./download`), which fans out over `bee.downloadReadableData` and returns
-`DownloadResult[]`. `DownloadOptions` comes from bee-js.
+`DownloadFilesResult { succeeded, failed }`. `DownloadOptions` comes from bee-js. Because `downloadReadableData` resolves
+at stream-open, `succeeded` means the stream opened — a failure while draining surfaces on the consumer's stream, not in
+`failed`. Aborts are not recorded as per-file failures; the post-settle abort check surfaces them instead.
 
 ## Core helpers reused (already present)
 

--- a/changelog/v2-api-file-read.md
+++ b/changelog/v2-api-file-read.md
@@ -1,0 +1,41 @@
+# v2/api-file-read — file read + version verbs
+
+Grows the file-read and per-file version verbs onto `FileManagerBase`, copied from the final v2 `fileManager.ts`. No
+lying stubs; the class still does not `implements FileManager` (the `// TODO` stays until the final PR). No earlier-PR
+method was modified — only imports were added.
+
+## Added — public methods
+
+- **`downloadFile(fileRecord, options?, requestOptions?)`** — convenience wrapper: downloads a single caller-held record
+  via `downloadFiles` and returns its one result.
+- **`downloadFiles(fileRecords, options?, requestOptions?)`** — downloads exactly the passed records with no drive
+  traversal or re-resolution (caller owns record currency). Maps each record to a `DownloadResource` and delegates to
+  transport `processDownload`.
+- **`getFileVersion(fr, version?, requestOptions?)`** — resolves a specific version from the file's own feed
+  (short-circuits to the in-memory head when the cached version matches), returning the `FileRecord` for that slot.
+  Read-only — no persistence.
+- **`restoreFileVersion(versionToRestore, requestOptions?)`** — republishes an older version's content refs as a new
+  head slot on the per-file feed, then bumps the fork version in the parent manifest. Refuses restoring the current head
+  slot. Emits `FILE_VERSION_RESTORED`.
+
+## Transport download path
+
+Content download is not re-implemented here. `downloadFiles` builds `DownloadResource[]` (from `./types/v2/download`)
+and calls transport's `processDownload` (from `./download`), which fans out over `bee.downloadReadableData` and returns
+`DownloadResult[]`. `DownloadOptions` comes from bee-js.
+
+## Core helpers reused (already present)
+
+- `loadRecord` is **not** needed by these verbs — version reads go directly through `store.getRecord` / `getFeedData`,
+  and the callers of the download verbs already hold their records.
+- `persistRecord` and `syncForkVersion` (introduced in api-file-write) are reused by `restoreFileVersion` to publish the
+  restored slot and update the fork version. `findDriveOrThrow` (api-drive) resolves the drive.
+
+## Per-file restore only — no folder/drive-level restore
+
+Per-file restore via the file feed slots is the only version-restore that exists. There is deliberately no folder- or
+drive-level restore, and none was added.
+
+## Gate
+
+- `pnpm run lint` and `build` clean

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -1,6 +1,7 @@
 import { Bee, BeeRequestOptions, DownloadOptions } from '@ethersphere/bee-js';
 
-import { DownloadResource, DownloadResult } from '../types/v2/download';
+import { DownloadFilesResult, DownloadResource, DownloadResult } from '../types/v2/download';
+import { FailedResult } from '../types/v2/utils';
 import { settlePromises } from '../utils/common';
 import { Logger } from '../utils/logger';
 
@@ -11,9 +12,10 @@ export async function processDownload(
   resources: DownloadResource[],
   options?: DownloadOptions,
   requestOptions?: BeeRequestOptions,
-): Promise<DownloadResult[]> {
+): Promise<DownloadFilesResult> {
   requestOptions?.signal?.throwIfAborted();
-  const results: DownloadResult[] = [];
+  const succeeded: DownloadResult[] = [];
+  const failed: FailedResult[] = [];
 
   await settlePromises(
     resources.map(async (r) => {
@@ -23,15 +25,17 @@ export async function processDownload(
         requestOptions,
       );
     }),
-    (value, ix) => results.push({ path: resources[ix].path, result: value }),
+    (value, ix) => succeeded.push({ path: resources[ix].path, result: value }),
     (reason, ix) => {
       if (requestOptions?.signal?.aborted) return;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      logger.error(`processDownload: failed to fetch ${resources[ix].path}: ${(reason as any)?.message || reason}`);
+      const message = (reason as any)?.message || String(reason);
+      logger.error(`processDownload: failed to fetch ${resources[ix].path}: ${message}`);
+      failed.push({ path: resources[ix].path, error: message });
     },
   );
 
   requestOptions?.signal?.throwIfAborted();
 
-  return results;
+  return { succeeded, failed };
 }

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -17,10 +17,10 @@ import {
   Topic,
 } from '@ethersphere/bee-js';
 
-import { DownloadResource, DownloadResult } from './types/v2/download';
+import { DownloadFilesResult, DownloadResource, DownloadResult } from './types/v2/download';
 import { DriveInfo, FileRecord, FolderInfo, ManifestHost, NodeStatus, NodeType } from './types/v2/info';
 import { UpdateItem, UploadFilesResult, UploadItem } from './types/v2/upload';
-import { ActReferences } from './types/v2/utils';
+import { ActReferences, FailedResult } from './types/v2/utils';
 import {
   fetchStamp,
   getFeedData,
@@ -41,7 +41,7 @@ import {
   ROOT_PATH,
 } from './utils/constants';
 import { generateRandomBytes } from './utils/crypto';
-import { DriveError, ErrorHandler, FileInfoError, SignerError } from './utils/errors';
+import { DriveError, ErrorHandler, FileError, FileInfoError, SignerError } from './utils/errors';
 import { FileManagerEvents } from './utils/events';
 import { Logger } from './utils/logger';
 import { assertActReferences, assertDriveInfoFromMetadata, assertReady } from './utils/v2/asserts';
@@ -440,7 +440,7 @@ export class FileManagerBase {
     }
 
     const succeeded: FileRecord[] = [];
-    const failed: { path: string; error: string }[] = [];
+    const failed: FailedResult[] = [];
     const owner = this.signerAddress;
 
     await awaitAllPromisesBounded(
@@ -623,7 +623,13 @@ export class FileManagerBase {
     options?: DownloadOptions,
     requestOptions?: BeeRequestOptions,
   ): Promise<DownloadResult> {
-    return (await this.downloadFiles([fileRecord], options, requestOptions))[0];
+    const { succeeded, failed } = await this.downloadFiles([fileRecord], options, requestOptions);
+
+    if (succeeded.length === 0) {
+      throw new FileError(`Failed to download ${fileRecord.path}: ${failed[0]?.error ?? 'unknown error'}`);
+    }
+
+    return succeeded[0];
   }
 
   /**
@@ -636,11 +642,11 @@ export class FileManagerBase {
     fileRecords: FileRecord[],
     options?: DownloadOptions,
     requestOptions?: BeeRequestOptions,
-  ): Promise<DownloadResult[]> {
+  ): Promise<DownloadFilesResult> {
     requestOptions?.signal?.throwIfAborted();
     assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
 
-    if (fileRecords.length === 0) return [];
+    if (fileRecords.length === 0) return { succeeded: [], failed: [] };
 
     const resources: DownloadResource[] = fileRecords.map((fr) => ({
       path: fr.path,
@@ -692,7 +698,7 @@ export class FileManagerBase {
       undefined,
       requestOptions,
     );
-    if (feedIndex.equals(FeedIndex.MINUS_ONE.toString())) {
+    if (feedIndex.equals(FeedIndex.MINUS_ONE)) {
       throw new FileInfoError('Record feed not found');
     }
 

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -3,6 +3,7 @@ import {
   Bee,
   BeeRequestOptions,
   Bytes,
+  DownloadOptions,
   FeedIndex,
   FileUploadOptions,
   Identifier,
@@ -16,6 +17,7 @@ import {
   Topic,
 } from '@ethersphere/bee-js';
 
+import { DownloadResource, DownloadResult } from './types/v2/download';
 import { DriveInfo, FileRecord, FolderInfo, ManifestHost, NodeStatus, NodeType } from './types/v2/info';
 import { UpdateItem, UploadFilesResult, UploadItem } from './types/v2/upload';
 import { ActReferences } from './types/v2/utils';
@@ -52,6 +54,7 @@ import {
   getDriveForkPath,
 } from './utils/v2/mantaray';
 import { assertValidRelativePath, pathSegments, splitPath } from './utils/v2/path';
+import { processDownload } from './download';
 import { EventEmitter, EventEmitterBase } from './eventEmitter';
 import { MantarayStore } from './mantarayStore';
 import { assertUploadableSource, processUpload } from './upload';
@@ -641,6 +644,121 @@ export class FileManagerBase {
     this.emitter.emit(FileManagerEvents.FILE_UPDATED, { record: fr });
 
     return fr;
+  }
+
+  // --- File read operations ---
+
+  // Download a single file the caller already holds as a FileRecord — convenience wrapper over
+  // downloadFiles(). Does not re-resolve against drive state (see downloadFiles).
+  async downloadFile(
+    fileRecord: FileRecord,
+    options?: DownloadOptions,
+    requestOptions?: BeeRequestOptions,
+  ): Promise<DownloadResult> {
+    return (await this.downloadFiles([fileRecord], options, requestOptions))[0];
+  }
+
+  /**
+   * Download files whose FileRecords the caller already holds — no drive traversal or hydration.
+   * Fetches exactly the passed records: it does NOT re-resolve them against current drive state,
+   * so the caller is responsible for record currency (a stale record fetches whatever it points at,
+   * e.g. an older version). For folder- or drive-based fetching that resolves fresh, use downloadFolder().
+   */
+  async downloadFiles(
+    fileRecords: FileRecord[],
+    options?: DownloadOptions,
+    requestOptions?: BeeRequestOptions,
+  ): Promise<DownloadResult[]> {
+    requestOptions?.signal?.throwIfAborted();
+    assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
+
+    if (fileRecords.length === 0) return [];
+
+    const resources: DownloadResource[] = fileRecords.map((fr) => ({
+      path: fr.path,
+      reference: fr.content.reference,
+      actHistoryAddress: fr.content.historyRef,
+      actPublisher: fr.actPublisher,
+    }));
+
+    return await processDownload(this.bee, resources, options, requestOptions);
+  }
+
+  // --- File version operations ---
+
+  async getFileVersion(
+    fr: FileRecord,
+    version?: string | FeedIndex,
+    requestOptions?: BeeRequestOptions,
+  ): Promise<FileRecord> {
+    assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
+
+    const localHead = this.fileInfoList.find((f) => f.topic === fr.topic);
+
+    if (localHead && localHead.version && version) {
+      const requested = new FeedIndex(version);
+      const cachedIdx = new FeedIndex(localHead.version);
+      if (cachedIdx.equals(requested)) {
+        return localHead;
+      }
+    }
+
+    const topic = new Topic(fr.topic);
+    const index = version !== undefined ? new FeedIndex(version).toBigInt() : undefined;
+    const feedData = await getFeedData(this.bee, topic, fr.owner, index, requestOptions);
+    if (feedData.feedIndex.equals(FeedIndex.MINUS_ONE)) {
+      throw new FileInfoError(`File feed not found for topic: ${fr.topic.slice(0, 6)}`);
+    }
+
+    return this.store.getRecord(topic.toString(), fr.actPublisher, feedData, requestOptions);
+  }
+
+  async restoreFileVersion(versionToRestore: FileRecord, requestOptions?: BeeRequestOptions): Promise<void> {
+    const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(versionToRestore.driveId).toString());
+
+    const { feedIndex, feedIndexNext } = await getFeedData(
+      this.bee,
+      new Topic(versionToRestore.topic),
+      versionToRestore.owner,
+      undefined,
+      requestOptions,
+    );
+    if (feedIndex.equals(FeedIndex.MINUS_ONE.toString())) {
+      throw new FileInfoError('Record feed not found');
+    }
+
+    if (!versionToRestore.version) {
+      throw new FileInfoError('Restore version has to be defined');
+    }
+
+    const versionToRestoreIndex = new FeedIndex(versionToRestore.version);
+    if (feedIndex.equals(versionToRestoreIndex)) {
+      throw new FileInfoError(
+        `Head Slot cannot be restored. Please select a version lesser than: ${versionToRestore.version}`,
+      );
+    }
+
+    const cached = this.fileInfoList.find((f) => f.topic === versionToRestore.topic);
+
+    const newVersion = feedIndexNext.toString();
+    const restored: FileRecord = {
+      ...versionToRestore,
+      path: cached?.path ?? versionToRestore.path,
+      version: newVersion,
+      content: {
+        reference: versionToRestore.content.reference,
+        historyRef: versionToRestore.content.historyRef,
+      },
+      timestamp: Date.now(),
+    };
+
+    await this.persistRecord(restored, requestOptions);
+    await this.syncForkVersion(cachedDrive, driveIx, restored.path, newVersion, publisher, requestOptions);
+
+    this.emitter.emit(FileManagerEvents.FILE_VERSION_RESTORED, {
+      restored,
+    });
   }
 
   // --- Private helpers ---

--- a/src/types/v2/download.ts
+++ b/src/types/v2/download.ts
@@ -1,5 +1,7 @@
 import { PublicKey } from '@ethersphere/bee-js';
 
+import { FailedResult } from './utils';
+
 export interface DownloadResource {
   path: string;
   reference: string;
@@ -10,4 +12,9 @@ export interface DownloadResource {
 export interface DownloadResult {
   path: string;
   result: ReadableStream<Uint8Array>;
+}
+
+export interface DownloadFilesResult {
+  succeeded: DownloadResult[];
+  failed: FailedResult[];
 }

--- a/src/types/v2/index.ts
+++ b/src/types/v2/index.ts
@@ -17,5 +17,5 @@ export type {
   UploadSource,
   UploadFilesResult,
 } from './upload';
-export type { DownloadResource, DownloadResult } from './download';
-export type { ActReferences, FeedPayloadResult, FeedReferenceResult, FeedResultWithIndex } from './utils';
+export type { DownloadFilesResult, DownloadResource, DownloadResult } from './download';
+export type { ActReferences, FeedPayloadResult, FeedReferenceResult, FeedResultWithIndex, FailedResult } from './utils';

--- a/src/types/v2/upload.ts
+++ b/src/types/v2/upload.ts
@@ -1,4 +1,5 @@
 import { FileRecord } from './info';
+import { FailedResult } from './utils';
 
 export interface BrowserUploadOptions {
   file: File;
@@ -29,5 +30,5 @@ export interface UpdateItem {
 
 export interface UploadFilesResult {
   succeeded: FileRecord[];
-  failed: { path: string; error: string }[];
+  failed: FailedResult[];
 }

--- a/src/types/v2/utils.ts
+++ b/src/types/v2/utils.ts
@@ -18,3 +18,8 @@ export interface FeedReferenceResult extends FeedUpdateHeaders {
 export interface FeedResultWithIndex extends FeedPayloadResult {
   feedIndexNext: FeedIndex;
 }
+
+export interface FailedResult {
+  path: string;
+  error: string;
+}


### PR DESCRIPTION
> Do NOT merge until PR #64 review is complete and merged.

# v2/api-file-read — file read + version verbs

Grows the file-read and per-file version verbs onto `FileManagerBase`, copied from the final v2 `fileManager.ts`. No
lying stubs; the class still does not `implements FileManager` (the `// TODO` stays until the final PR). No earlier-PR
method was modified — only imports were added.

## Added — public methods

- **`downloadFile(fileRecord, options?, requestOptions?)`** — convenience wrapper: downloads a single caller-held record
  via `downloadFiles` and returns its one result.
- **`downloadFiles(fileRecords, options?, requestOptions?)`** — downloads exactly the passed records with no drive
  traversal or re-resolution (caller owns record currency). Maps each record to a `DownloadResource` and delegates to
  transport `processDownload`.
- **`getFileVersion(fr, version?, requestOptions?)`** — resolves a specific version from the file's own feed
  (short-circuits to the in-memory head when the cached version matches), returning the `FileRecord` for that slot.
  Read-only — no persistence.
- **`restoreFileVersion(versionToRestore, requestOptions?)`** — republishes an older version's content refs as a new
  head slot on the per-file feed, then bumps the fork version in the parent manifest. Refuses restoring the current head
  slot. Emits `FILE_VERSION_RESTORED`.

## Transport download path

Content download is not re-implemented here. `downloadFiles` builds `DownloadResource[]` (from `./types/v2/download`)
and calls transport's `processDownload` (from `./download`), which fans out over `bee.downloadReadableData` and returns
`DownloadResult[]`. `DownloadOptions` comes from bee-js.

## Core helpers reused (already present)

- `loadRecord` is **not** needed by these verbs — version reads go directly through `store.getRecord` / `getFeedData`,
  and the callers of the download verbs already hold their records.
- `persistRecord` and `syncForkVersion` (introduced in api-file-write) are reused by `restoreFileVersion` to publish the
  restored slot and update the fork version. `findDriveOrThrow` (api-drive) resolves the drive.

## Per-file restore only — no folder/drive-level restore

Per-file restore via the file feed slots is the only version-restore that exists. There is deliberately no folder- or
drive-level restore, and none was added.

## Gate

- `pnpm run lint` and `build` clean