### PR TITLE
v2/api-trash: trash lifecycle methods

### DIFF
--- a/changelog/v2-api-drive.md
+++ b/changelog/v2-api-drive.md
@@ -16,7 +16,7 @@ only validates stamps. There is no drive-teardown verb that touches the underlyi
 ## Added — private helpers (arrive with their first consumer)
 
 - **`findDriveOrThrow(driveId)`** — resolves a drive id to `{ driveIx, cachedDrive }` from `driveList` or throws
-  `DriveError`. First used here by `forgetDrive`.
+  `DriveError` and verifies the driveId format. First used here by `forgetDrive`.
 - **`pruneDriveMetadata(driveInfo, driveIndex, stateTopic, publisher, requestOptions?)`** — the teardown step for
   `forgetDrive`: removes the drive's fork from the admin mantaray, re-saves the admin manifest, splices the drive out of
   `driveList`, evicts its store entry, and drops its records from `fileInfoList`.

--- a/changelog/v2-api-trash.md
+++ b/changelog/v2-api-trash.md
@@ -38,8 +38,8 @@ invariant holds.
 
 ## Overlay helpers — shared with api-folder
 
-- **`setTrashState(driveId, entry, isTrashed, requestOptions?)`** — introduced here: guards double-trash /
-  double-recover, persists the admin drive fork, and updates the in-memory overlay.
+- **`setTrashState(driveId: string | undefined, entry, isTrashed, requestOptions?)`** — introduced here: guards
+  double-trash / double-recover, persists the admin drive fork, and updates the in-memory overlay.
 - **`persistAdminDriveFork`** and **`pruneTrashOverlay`** were already introduced in `v2/api-folder` (its `move` /
   `forget` mutate the same overlay) and are reused as-is here — shared ownership across the two PRs is deliberate.
 

--- a/changelog/v2-api-trash.md
+++ b/changelog/v2-api-trash.md
@@ -38,8 +38,8 @@ invariant holds.
 
 ## Overlay helpers — shared with api-folder
 
-- **`setTrashState(driveId: string | undefined, entry, isTrashed, requestOptions?)`** — introduced here: guards
-  double-trash / double-recover, persists the admin drive fork, and updates the in-memory overlay.
+- **`setTrashState(driveId, entry, isTrashed, requestOptions?)`** — introduced here: guards double-trash /
+  double-recover, persists the admin drive fork, and updates the in-memory overlay.
 - **`persistAdminDriveFork`** and **`pruneTrashOverlay`** were already introduced in `v2/api-folder` (its `move` /
   `forget` mutate the same overlay) and are reused as-is here — shared ownership across the two PRs is deliberate.
 

--- a/changelog/v2-api-trash.md
+++ b/changelog/v2-api-trash.md
@@ -1,0 +1,48 @@
+# v2/api-trash — trash lifecycle verbs
+
+Grows the trash lifecycle onto `FileManagerBase`. No lying stubs; the class still does not `implements FileManager` (the
+`// TODO` stays — the interface rewrite and the `implements` flip land in the following `v2/api-interface` PR). No
+earlier-PR method was modified.
+
+## Added — public methods
+
+- **`trashFile(record, requestOptions?)`** / **`recoverFile(record, requestOptions?)`** — soft-delete / restore a file
+  by toggling its topic in the drive's trash overlay. Emit `FILE_TRASHED` / `FILE_RECOVERED`.
+- **`trashFolder(folder, requestOptions?)`** / **`recoverFolder(folder, requestOptions?)`** — same for a folder,
+  recording only the folder's own topic (no subtree propagation — a single overlay entry regardless of depth). Emit
+  `FOLDER_TRASHED` / `FOLDER_RECOVERED`.
+- **`listTrash(driveId, requestOptions?)`** — hydrates the overlay entries into full `NodeEntry` objects with
+  `status = Trashed`, reading straight from the overlay with no tree walk (cost is proportional to the number of trashed
+  roots, not drive size).
+
+## Owner-private trash overlay model
+
+Trash state is **not** a per-node feed write. It lives entirely in the owner-private admin metadata as
+`DriveInfo.trashedNodes: TrashEntry[]`, keyed by node topic:
+
+- **Topic-keyed overlay** — trash / recover add or remove a `TrashEntry` for the node's topic; nothing on the node's own
+  feed or content changes.
+- **Status is derived, never persisted** — `MantarayStore.saveRecord` strips `status` from the record before persisting,
+  so it never reaches Swarm. A node's status is computed on demand by `getRecordStatus(drive, topic)`, which returns
+  `Trashed` iff the topic is in `drive.trashedNodes`, else `Active`. The status field is populated only on the in-memory
+  `fileInfoList` / returned objects.
+
+## Cold-load status derivation — verified
+
+Traced the fresh-load path (`initialize` → `initDriveList`): each drive's overlay is carried in its admin manifest fork
+metadata (`swarm-drive-trashed-nodes`, written by `driveForkMetadata`) and reconstructed on load via
+`assertDriveInfoFromMetadata` → `parseTrashedNodes`. Records are then hydrated lazily (`listFolder` → `loadRecord`) and
+their status is set from `getRecordStatus` against that overlay. A record whose topic is present in the loaded overlay
+therefore comes back with `Trashed` status, with no per-node status field ever having been persisted — the derivation
+invariant holds.
+
+## Overlay helpers — shared with api-folder
+
+- **`setTrashState(driveId, entry, isTrashed, requestOptions?)`** — introduced here: guards double-trash /
+  double-recover, persists the admin drive fork, and updates the in-memory overlay.
+- **`persistAdminDriveFork`** and **`pruneTrashOverlay`** were already introduced in `v2/api-folder` (its `move` /
+  `forget` mutate the same overlay) and are reused as-is here — shared ownership across the two PRs is deliberate.
+
+## Gate
+
+- `pnpm run lint` and `build` clean

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,7 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'error',
       '@typescript-eslint/no-non-null-assertion': 'error',
       'require-await': 'error',
+      eqeqeq: 'error',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -1177,6 +1177,109 @@ export class FileManagerBase {
     this.emitter.emit(FileManagerEvents.FILE_FORGOTTEN, { record: forgotten, path });
   }
 
+  // --- Trash operations ---
+
+  async trashFile(record: FileRecord, requestOptions?: BeeRequestOptions): Promise<void> {
+    await this.setTrashState(
+      record.driveId,
+      { topic: record.topic, type: NodeType.File, path: record.path, version: record.version },
+      true,
+      requestOptions,
+    );
+    record.status = NodeStatus.Trashed;
+    this.emitter.emit(FileManagerEvents.FILE_TRASHED, { record });
+  }
+
+  async recoverFile(record: FileRecord, requestOptions?: BeeRequestOptions): Promise<void> {
+    await this.setTrashState(
+      record.driveId,
+      { topic: record.topic, type: NodeType.File, path: record.path },
+      false,
+      requestOptions,
+    );
+    record.status = NodeStatus.Active;
+    this.emitter.emit(FileManagerEvents.FILE_RECOVERED, { record });
+  }
+
+  async trashFolder(folder: FolderInfo, requestOptions?: BeeRequestOptions): Promise<void> {
+    await this.setTrashState(
+      folder.driveId,
+      { topic: folder.topic, type: NodeType.Folder, path: folder.path },
+      true,
+      requestOptions,
+    );
+    folder.status = NodeStatus.Trashed;
+    this.emitter.emit(FileManagerEvents.FOLDER_TRASHED, { folder });
+  }
+
+  async recoverFolder(folder: FolderInfo, requestOptions?: BeeRequestOptions): Promise<void> {
+    await this.setTrashState(
+      folder.driveId,
+      { topic: folder.topic, type: NodeType.Folder, path: folder.path },
+      false,
+      requestOptions,
+    );
+    folder.status = NodeStatus.Active;
+    this.emitter.emit(FileManagerEvents.FOLDER_RECOVERED, { folder });
+  }
+
+  async listTrash(driveId: string | Identifier, requestOptions?: BeeRequestOptions): Promise<NodeEntry[]> {
+    requestOptions?.signal?.throwIfAborted();
+
+    const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
+    const { cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+
+    const entries = cachedDrive.trashedNodes ?? [];
+    const owner = this.signerAddress;
+    const trashedResults: NodeEntry[] = [];
+
+    await awaitAllPromisesBounded(
+      entries.map((entry) => async (): Promise<NodeEntry | null> => {
+        const version = entry.version ? new FeedIndex(entry.version).toBigInt() : undefined;
+
+        const feedData = await getFeedData(this.bee, new Topic(entry.topic), owner, version, requestOptions);
+
+        if (feedData.feedIndex.equals(FeedIndex.MINUS_ONE)) {
+          this.logger.warn(`listTrash: feed not found for ${entry.path} — skipping`);
+          return null;
+        }
+
+        if (entry.type === NodeType.File) {
+          const fr = await this.store.getRecord(entry.topic, publisher, feedData, requestOptions);
+          fr.path = entry.path;
+          fr.status = NodeStatus.Trashed;
+          return fr;
+        }
+
+        const manifestRef = feedData.payload.toJSON() as ActReferences;
+        assertActReferences(manifestRef);
+
+        return {
+          type: NodeType.Folder,
+          owner,
+          topic: entry.topic,
+          manifestRef,
+          batchId: cachedDrive.batchId,
+          redundancyLevel: cachedDrive.redundancyLevel,
+          actPublisher: publisher,
+          path: entry.path,
+          driveId: cachedDrive.id,
+          status: NodeStatus.Trashed,
+        };
+      }),
+      MAX_CONCURRENT_FEED_FETCHES,
+      (node) => {
+        if (node) trashedResults.push(node);
+      },
+      (reason, ix) => {
+        if (requestOptions?.signal?.aborted) return;
+        this.logger.error(`listTrash: failed to resolve ${entries[ix].path}: ${reason}`);
+      },
+    );
+
+    return trashedResults;
+  }
+
   // --- Private helpers ---
 
   private async initPublisher(requestOptions?: BeeRequestOptions): Promise<void> {
@@ -1580,6 +1683,30 @@ export class FileManagerBase {
     } else {
       this.fileInfoList.push(fr);
     }
+  }
+
+  private async setTrashState(
+    driveId: string,
+    entry: TrashEntry,
+    isTrashed: boolean,
+    requestOptions?: BeeRequestOptions,
+  ): Promise<DriveInfo> {
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const isAlreadyTrashed = getRecordStatus(cachedDrive, entry.topic) == NodeStatus.Trashed;
+
+    if (isTrashed && isAlreadyTrashed) {
+      throw new FileInfoError(`Already trashed: ${entry.path}`);
+    }
+    if (!isTrashed && !isAlreadyTrashed) {
+      throw new FileInfoError(`Not trashed, cannot recover: ${entry.path}`);
+    }
+
+    const current = cachedDrive.trashedNodes ?? [];
+    const withoutEntry = current.filter((n) => n.topic !== entry.topic);
+    cachedDrive.trashedNodes = isTrashed ? [...withoutEntry, entry] : withoutEntry;
+    await this.persistAdminDriveFork(driveIx, requestOptions);
+
+    return cachedDrive;
   }
 
   private async persistAdminDriveFork(driveIx: number, requestOptions?: BeeRequestOptions): Promise<void> {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -216,7 +216,7 @@ export class FileManagerBase {
 
   async forgetDrive(driveId: string | Identifier, requestOptions?: BeeRequestOptions): Promise<void> {
     const { publisher, stateFeedTopic } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
 
     if (cachedDrive.isAdmin) {
       throw new DriveError('Cannot forget admin drive');
@@ -237,7 +237,7 @@ export class FileManagerBase {
   ): Promise<FileRecord> {
     requestOptions?.signal?.throwIfAborted();
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
 
     assertUploadableSource(item);
 
@@ -312,7 +312,7 @@ export class FileManagerBase {
     requestOptions?.signal?.throwIfAborted();
 
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
 
     if (!items.length) {
       throw new FileInfoError('uploadFiles requires at least one entry');
@@ -544,7 +544,7 @@ export class FileManagerBase {
   ): Promise<FileRecord> {
     requestOptions?.signal?.throwIfAborted();
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
 
     const noMeta = !changes.customMetadata || Object.keys(changes.customMetadata).length === 0;
     if (noMeta && !changes.item) {
@@ -707,7 +707,7 @@ export class FileManagerBase {
     if (!versionToRestore.driveId) {
       throw new FileInfoError('Cannot restore: record has no driveId — obtain it via listFolder/getFileVersion first');
     }
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(versionToRestore.driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(versionToRestore.driveId);
 
     const { feedIndex, feedIndexNext } = await getFeedData(
       this.bee,
@@ -764,7 +764,7 @@ export class FileManagerBase {
   ): Promise<FolderInfo> {
     requestOptions?.signal?.throwIfAborted();
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
 
     if (!folderName || folderName.includes('/')) {
       throw new DriveError(`Invalid folder name ${folderName}`);
@@ -809,7 +809,7 @@ export class FileManagerBase {
     requestOptions?.signal?.throwIfAborted();
 
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { cachedDrive } = this.findDriveOrThrow(driveId);
 
     const { host: startHost } = await this.store.resolveHost(cachedDrive, path, publisher, requestOptions);
     const startBasePath = normalizePath(path);
@@ -1105,7 +1105,7 @@ export class FileManagerBase {
   async forget(driveId: string | Identifier, path: string, requestOptions?: BeeRequestOptions): Promise<void> {
     requestOptions?.signal?.throwIfAborted();
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
 
     if (!path || path === ROOT_PATH) {
       throw new DriveError('Cannot forget drive root');
@@ -1219,7 +1219,7 @@ export class FileManagerBase {
     requestOptions?.signal?.throwIfAborted();
 
     const { publisher } = assertReady(this.publisher, this.isInitialized, this.stateFeedTopic);
-    const { cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    const { cachedDrive } = this.findDriveOrThrow(driveId);
 
     const entries = cachedDrive.trashedNodes ?? [];
     const owner = this.signerAddress;
@@ -1527,11 +1527,12 @@ export class FileManagerBase {
     this._adminStamp = adminStamp;
   }
 
-  private findDriveOrThrow(driveId: string): { driveIx: number; cachedDrive: DriveInfo } {
-    const driveIx = this.driveList.findIndex((d) => d.id === driveId);
+  private findDriveOrThrow(driveId: string | Identifier): { driveIx: number; cachedDrive: DriveInfo } {
+    const driveIdStr = new Identifier(driveId).toString();
+    const driveIx = this.driveList.findIndex((d) => d.id === driveIdStr);
 
     if (driveIx === -1) {
-      throw new DriveError(`Drive with id ${driveId.slice(0, 6)} not found`);
+      throw new DriveError(`Drive with id ${driveIdStr.slice(0, 6)} not found`);
     }
 
     const cachedDrive = this.driveList[driveIx];
@@ -1680,12 +1681,16 @@ export class FileManagerBase {
   }
 
   private async setTrashState(
-    driveId: string,
+    driveId: string | undefined,
     entry: TrashEntry,
     isTrashed: boolean,
     requestOptions?: BeeRequestOptions,
   ): Promise<DriveInfo> {
-    const { driveIx, cachedDrive } = this.findDriveOrThrow(new Identifier(driveId).toString());
+    if (!driveId) {
+      throw new FileInfoError(`Drive ID missing for: ${entry.path}`);
+    }
+
+    const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
     const isAlreadyTrashed = getRecordStatus(cachedDrive, entry.topic) == NodeStatus.Trashed;
 
     if (isTrashed && isAlreadyTrashed) {

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -1240,6 +1240,8 @@ export class FileManagerBase {
           const fr = await this.store.getRecord(entry.topic, publisher, feedData, requestOptions);
           fr.path = entry.path;
           fr.status = NodeStatus.Trashed;
+          fr.driveId = cachedDrive.id;
+
           return fr;
         }
 
@@ -1691,7 +1693,7 @@ export class FileManagerBase {
     }
 
     const { driveIx, cachedDrive } = this.findDriveOrThrow(driveId);
-    const isAlreadyTrashed = getRecordStatus(cachedDrive, entry.topic) == NodeStatus.Trashed;
+    const isAlreadyTrashed = getRecordStatus(cachedDrive, entry.topic) === NodeStatus.Trashed;
 
     if (isTrashed && isAlreadyTrashed) {
       throw new FileInfoError(`Already trashed: ${entry.path}`);

--- a/src/utils/v2/common.ts
+++ b/src/utils/v2/common.ts
@@ -2,7 +2,7 @@ import { DriveInfo, NodeStatus } from '../../types/v2/info';
 import { Logger } from '../logger';
 
 const logger = Logger.getInstance();
-
+// TODO: can this be used in config? --> config: max num of parallel down/up ops ?
 export async function awaitAllPromisesBounded<T>(
   tasks: (() => Promise<T>)[],
   limit: number,


### PR DESCRIPTION
> Do NOT merge until PR #66 review is complete and merged.

# v2/api-trash — trash lifecycle verbs

Grows the trash lifecycle onto `FileManagerBase`. No lying stubs; the class still does not `implements FileManager` (the
`// TODO` stays — the interface rewrite and the `implements` flip land in the following `v2/api-interface` PR). No
earlier-PR method was modified.

## Added — public methods

- **`trashFile(record, requestOptions?)`** / **`recoverFile(record, requestOptions?)`** — soft-delete / restore a file
  by toggling its topic in the drive's trash overlay. Emit `FILE_TRASHED` / `FILE_RECOVERED`.
- **`trashFolder(folder, requestOptions?)`** / **`recoverFolder(folder, requestOptions?)`** — same for a folder,
  recording only the folder's own topic (no subtree propagation — a single overlay entry regardless of depth). Emit
  `FOLDER_TRASHED` / `FOLDER_RECOVERED`.
- **`listTrash(driveId, requestOptions?)`** — hydrates the overlay entries into full `NodeEntry` objects with
  `status = Trashed`, reading straight from the overlay with no tree walk (cost is proportional to the number of trashed
  roots, not drive size).

## Owner-private trash overlay model

Trash state is **not** a per-node feed write. It lives entirely in the owner-private admin metadata as
`DriveInfo.trashedNodes: TrashEntry[]`, keyed by node topic:

- **Topic-keyed overlay** — trash / recover add or remove a `TrashEntry` for the node's topic; nothing on the node's own
  feed or content changes.
- **Status is derived, never persisted** — `MantarayStore.saveRecord` strips `status` from the record before persisting,
  so it never reaches Swarm. A node's status is computed on demand by `getRecordStatus(drive, topic)`, which returns
  `Trashed` iff the topic is in `drive.trashedNodes`, else `Active`. The status field is populated only on the in-memory
  `fileInfoList` / returned objects.

## Cold-load status derivation — verified

Traced the fresh-load path (`initialize` → `initDriveList`): each drive's overlay is carried in its admin manifest fork
metadata (`swarm-drive-trashed-nodes`, written by `driveForkMetadata`) and reconstructed on load via
`assertDriveInfoFromMetadata` → `parseTrashedNodes`. Records are then hydrated lazily (`listFolder` → `loadRecord`) and
their status is set from `getRecordStatus` against that overlay. A record whose topic is present in the loaded overlay
therefore comes back with `Trashed` status, with no per-node status field ever having been persisted — the derivation
invariant holds.

## Overlay helpers — shared with api-folder

- **`setTrashState(driveId, entry, isTrashed, requestOptions?)`** — introduced here: guards double-trash /
  double-recover, persists the admin drive fork, and updates the in-memory overlay.
- **`persistAdminDriveFork`** and **`pruneTrashOverlay`** were already introduced in `v2/api-folder` (its `move` /
  `forget` mutate the same overlay) and are reused as-is here — shared ownership across the two PRs is deliberate.

## Gate

- `pnpm run lint` and `build` clean